### PR TITLE
Setup MkDocs documentation with Peregrine specifications

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,65 @@
+# CLAUDE.md - Project Guidelines
+
+This repository documents a Tripoli Level 1 certification rocket build using the Apogee Peregrine dual deployment kit.
+
+## Repository Purpose
+
+- Document rocket build for CRO (Club Range Officer) review
+- Provide calculations with formulas for verification
+- Store OpenRocket simulation files and results
+- Maintain flight logs and checklists
+
+## Documentation System
+
+- **Framework**: MkDocs with Material theme
+- **Math**: MathJax for LaTeX formulas
+- **Diagrams**: Mermaid for flowcharts
+- **Output**: GitHub Pages static site
+
+## File Structure
+
+```
+MyLevel1Peregrine/
+├── docs/                    # MkDocs content
+│   ├── index.md            # Home page
+│   ├── specifications/     # Rocket specs
+│   ├── construction/       # Build log
+│   ├── calculations/       # Formulas and calculations
+│   ├── simulations/        # OpenRocket results
+│   ├── flight/             # Checklists and logs
+│   └── photos/             # Images
+├── openrocket/             # .ork simulation files
+├── mkdocs.yml              # Site configuration
+└── CLAUDE.md               # This file
+```
+
+## Building the Documentation
+
+```bash
+# Install MkDocs with Material theme
+pip install mkdocs-material
+
+# Serve locally
+mkdocs serve
+
+# Build static site
+mkdocs build
+
+# Deploy to GitHub Pages
+mkdocs gh-deploy
+```
+
+## Key Specifications (Apogee Peregrine)
+
+- Length: 68.8" (175 cm)
+- Diameter: 4.0" (98mm)
+- Motor mount: 38mm (29mm with adapter)
+- Weight: ~5+ lbs dry
+- Dual deployment capable
+
+## Conventions
+
+- All measurements include both imperial and metric
+- Formulas shown with variable definitions
+- Photos named descriptively: `YYYYMMDD-description.jpg`
+- Flight data recorded with altimeter downloads

--- a/docs/calculations/ejection-charges.md
+++ b/docs/calculations/ejection-charges.md
@@ -1,0 +1,99 @@
+# Ejection Charge Calculations
+
+## Black Powder Charge Formula
+
+The standard formula for calculating black powder ejection charge:
+
+$$m_{BP} = \frac{\Delta P \cdot V \cdot C}{R \cdot T}$$
+
+Simplified practical formula:
+
+$$m_{BP} (grams) = \frac{D^2 \cdot L}{2270}$$
+
+Where:
+
+- $D$ = Tube inside diameter (inches)
+- $L$ = Bay length (inches)
+
+!!! note "Safety Factor"
+    Add 10-20% to calculated charge for reliable deployment.
+
+## Peregrine Bay Calculations
+
+### Known Values
+
+| Parameter | Value |
+|-----------|-------|
+| Body Tube ID | ~3.9" (actual ID of 98mm tube) |
+| Pressure | 15 psi (typical) |
+
+### Drogue Bay (Forward)
+
+*To be measured during build*
+
+| Parameter | Value |
+|-----------|-------|
+| Length | TBD inches |
+| Volume | TBD in³ |
+| BP Charge | TBD grams |
+
+### Main Bay (Aft)
+
+*To be measured during build*
+
+| Parameter | Value |
+|-----------|-------|
+| Length | TBD inches |
+| Volume | TBD in³ |
+| BP Charge | TBD grams |
+
+## RockSim Calculation
+
+RockSim includes a built-in ejection charge calculator:
+
+1. Open Peregrine design file
+2. Go to Simulation menu
+3. Select "Ejection Charge Calculator"
+4. Enter bay dimensions
+5. Get recommended charge size
+
+## Ground Test Procedure
+
+!!! warning "Always Ground Test"
+    Never fly without ground testing ejection charges!
+
+### Test Procedure
+
+1. Assemble rocket without motor
+2. Load recovery gear as for flight
+3. Install e-match with calculated charge
+4. Secure rocket horizontally
+5. Clear area and fire charge
+6. Verify clean separation and chute deployment
+
+### Test Criteria
+
+- [ ] Clean separation
+- [ ] All sections stay connected via shock cord
+- [ ] Parachute(s) fully deploy
+- [ ] No damage to components
+- [ ] Adequate force (increase charge if weak)
+
+## Alternative: CO2 Ejection
+
+Apogee offers a CO2 ejection system:
+
+- No black powder required
+- Peregrine Starter Kit includes:
+  - 4x 8-gram cartridges
+  - 4x 12-gram cartridges
+  - Hardware for 2 systems
+
+## Charge Quantities Summary
+
+*To be filled after bay measurements*
+
+| Bay | Primary | Backup (+15%) |
+|-----|---------|---------------|
+| Drogue | TBD g | TBD g |
+| Main | TBD g | TBD g |

--- a/docs/calculations/rail-exit.md
+++ b/docs/calculations/rail-exit.md
@@ -1,0 +1,92 @@
+# Rail Exit Velocity
+
+## Why It Matters
+
+The rocket must achieve sufficient velocity before leaving the launch rail for the fins to provide aerodynamic stability. Below this velocity, the rocket may:
+
+- Weathercock into wind
+- Fly unstable trajectory
+- Tip over on the pad
+
+## Minimum Rail Exit Velocity
+
+!!! success "Rule of Thumb"
+    Minimum rail exit velocity: **50 ft/s (15 m/s)**
+    
+    Recommended: **60-80 ft/s** for margin of safety
+
+## Physics
+
+Rail exit velocity depends on:
+
+$$V_{exit} = \sqrt{V_0^2 + 2 \cdot a_{avg} \cdot L_{rail}}$$
+
+Where:
+
+- $V_0$ = Initial velocity (0 for standing start)
+- $a_{avg}$ = Average acceleration during rail travel
+- $L_{rail}$ = Effective rail length
+
+Simplified:
+
+$$V_{exit} = \sqrt{\frac{2 \cdot F_{avg} \cdot L_{rail}}{m}}$$
+
+Where:
+
+- $F_{avg}$ = Average thrust force (N)
+- $m$ = Liftoff mass (kg)
+
+## Minimum Rail Length
+
+Rearranging for rail length:
+
+$$L_{rail} = \frac{m \cdot V_{exit}^2}{2 \cdot F_{avg}}$$
+
+## Peregrine Calculations
+
+### Estimated Values
+
+| Parameter | Value |
+|-----------|-------|
+| Liftoff Mass | ~6 lbs (~2.7 kg) with H motor |
+| Target Exit Velocity | 60 ft/s (18 m/s) |
+
+### Example: AeroTech H180W
+
+| Parameter | Value |
+|-----------|-------|
+| Average Thrust | 180 N (40 lbf) |
+| Liftoff Mass | ~2.7 kg |
+| Min Rail Length | Calculate below |
+
+$$L_{rail} = \frac{2.7 \cdot 18^2}{2 \cdot 180} = \frac{874.8}{360} = 2.4 m \approx 8 ft$$
+
+!!! note "Rail Length"
+    An 8-foot (2.4m) rail should provide adequate exit velocity for the Peregrine on H motors.
+    
+    Standard high-power rail lengths:
+    - 6 ft (1.8m) - marginal for heavy rockets
+    - 8 ft (2.4m) - good for most HPR
+    - 10 ft (3m) - excellent margin
+
+## Simulation Verification
+
+OpenRocket/RockSim calculate rail exit velocity:
+
+*Insert simulation results here*
+
+| Motor | Rail Length | Exit Velocity | Status |
+|-------|-------------|---------------|--------|
+| H180W | 6 ft | TBD | TBD |
+| H180W | 8 ft | TBD | TBD |
+| H100W | 8 ft | TBD | TBD |
+
+## Wind Considerations
+
+In windy conditions:
+
+- Higher exit velocity needed
+- Consider longer rail
+- Or postpone launch if marginal
+
+Rule: Add 10 ft/s to minimum for each 10 mph wind.

--- a/docs/calculations/stability.md
+++ b/docs/calculations/stability.md
@@ -1,0 +1,87 @@
+# Stability Calculations
+
+## Stability Criteria
+
+For a stable rocket flight:
+
+$$\text{Stability Margin} = \frac{X_{CP} - X_{CG}}{d} \geq 1.0$$
+
+Where:
+
+- $X_{CP}$ = Center of Pressure location (from nose tip)
+- $X_{CG}$ = Center of Gravity location (from nose tip)
+- $d$ = Body tube diameter (caliber)
+
+!!! success "Target"
+    CG should be **1 to 2 calibers** ahead of CP
+    
+    - Less than 1 caliber: marginally stable
+    - More than 2 calibers: will weathercock
+
+## Peregrine Stability
+
+With 4" diameter body:
+
+- 1 caliber = 4 inches
+- Target: CG 4-8" ahead of CP
+
+| Configuration | CG | CP | Margin | Status |
+|--------------|-----|-----|--------|--------|
+| *To be filled from OpenRocket* | | | | |
+
+## Measuring CG
+
+### Method: Balance Point
+
+1. Fully load rocket (motor, recovery, electronics)
+2. Balance on finger or rod
+3. Mark balance point
+4. Measure from nose tip
+
+### Weight Considerations
+
+| Item | Approx Weight | Notes |
+|------|---------------|-------|
+| Airframe (empty) | ~5 lbs | As built |
+| Altimeter | 0.5-2 oz | Varies by model |
+| Motor (H180) | ~8 oz | Loaded |
+| Recovery gear | ~4 oz | Packed |
+
+## CP Calculation Methods
+
+### Barrowman Equations
+
+Classic analytical method for CP location. Implemented in:
+
+- RockSim
+- OpenRocket
+
+### Cardboard Cutout Method
+
+Simple physical approximation:
+
+1. Draw rocket profile on cardboard
+2. Cut out profile
+3. Balance cutout
+4. Balance point ≈ CP
+
+!!! note "Conservative Method"
+    Cardboard cutout gives a conservative estimate.
+    Actual CP is usually further aft.
+
+## Dynamic Stability
+
+Beyond static stability, dynamic factors include:
+
+- Launch velocity (affects weathercocking)
+- Wind conditions
+- Fin size and shape
+- Mass distribution
+
+RockSim/OpenRocket simulate these factors.
+
+## Simulation Results
+
+*Insert OpenRocket stability analysis here*
+
+See [OpenRocket Results](../simulations/openrocket.md) for full simulation data.

--- a/docs/calculations/vent-holes.md
+++ b/docs/calculations/vent-holes.md
@@ -1,0 +1,88 @@
+# Vent Hole Calculations
+
+## Purpose
+
+Vent holes (static ports) allow the altimeter to sense ambient air pressure during flight. Without proper venting, pressure differentials can cause:
+
+- Inaccurate altitude readings
+- Premature or delayed deployment
+- Structural stress on airframe
+
+## Vent Hole Formula
+
+Minimum vent hole area:
+
+$$A_{vent} = \frac{A_{tube} \cdot V_{descent}}{V_{sound}} \cdot N$$
+
+Simplified rule of thumb:
+
+$$A_{vent} \geq \frac{V_{bay}}{100}$$
+
+Where:
+
+- $A_{vent}$ = Total vent area (in²)
+- $V_{bay}$ = Bay internal volume (in³)
+
+## Practical Guidelines
+
+### Number of Holes
+
+- Minimum: 2 holes (180° apart)
+- Recommended: 3-4 holes (evenly spaced)
+- Prevents asymmetric pressure effects
+
+### Hole Size
+
+Common sizes for 4" diameter rockets:
+
+| Hole Diameter | Area per Hole | 4 Holes Total |
+|---------------|---------------|---------------|
+| 1/8" (3mm) | 0.012 in² | 0.049 in² |
+| 3/16" (5mm) | 0.028 in² | 0.110 in² |
+| 1/4" (6mm) | 0.049 in² | 0.196 in² |
+
+### Placement
+
+!!! tip "Hole Location"
+    - Place in e-bay coupler section
+    - Position near altimeter sensor
+    - Avoid direct line to ejection charge
+    - Not too close to tube joints
+
+## Peregrine Vent Holes
+
+*To be determined during build*
+
+| Parameter | Value |
+|-----------|-------|
+| E-bay length | TBD inches |
+| Number of holes | TBD |
+| Hole diameter | TBD |
+| Total vent area | TBD in² |
+
+## Additional Considerations
+
+### Breather Holes vs Static Ports
+
+- **Static Ports**: For altimeter pressure sensing
+- **Breather Holes**: For recovery bay equalization
+
+Both may be needed in different locations.
+
+### Switch Hole
+
+If using external arming switch:
+
+- Switch mounting hole also provides venting
+- Account for this area in calculations
+- Use switch band for clean installation
+
+## Testing
+
+Verify altimeter function after drilling:
+
+1. Power on altimeter
+2. Seal one end of e-bay
+3. Gently blow into/suck on other end
+4. Altimeter should show altitude change
+5. Altitude should return to zero when released

--- a/docs/construction/build-log.md
+++ b/docs/construction/build-log.md
@@ -1,0 +1,74 @@
+# Build Log
+
+This page documents the construction progress of my Apogee Peregrine.
+
+## Build Status
+
+!!! info "Current Phase"
+    Documentation in progress - build not yet started
+
+## Planned Build Sequence
+
+Following Apogee's recommended construction order:
+
+1. **Motor Mount Assembly**
+    - Mark motor tube
+    - Attach centering rings
+    - Install Kevlar shock cord anchor
+    - Add thrust block (if using short motors)
+
+2. **Fin Installation**
+    - Prepare fin slots in body tube
+    - Test fit fins
+    - Tack with CA glue
+    - Internal fillets with epoxy
+    - External fillets
+
+3. **Electronics Bay**
+    - Sand bulkhead edges
+    - Install stop rings
+    - Glue threaded rod alignment rails
+    - Assemble sled
+    - Install switch band
+    - Mount eyebolts
+
+4. **Airframe Assembly**
+    - Join body tube sections with couplers
+    - Install motor mount
+    - Add rail buttons
+
+5. **Recovery System**
+    - Attach shock cords
+    - Install quick links
+    - Attach chute protectors
+
+6. **Finishing**
+    - Fill spirals (if desired)
+    - Prime
+    - Paint
+    - Apply decals
+
+---
+
+## Build Entries
+
+*Build log entries will be added here as construction progresses*
+
+<!-- Template for entries:
+
+### YYYY-MM-DD: [Phase Name]
+
+**Work completed:**
+
+- Item 1
+- Item 2
+
+**Photos:**
+
+![Description](../photos/filename.jpg)
+
+**Notes:**
+
+Any observations or deviations from instructions.
+
+-->

--- a/docs/construction/ebay.md
+++ b/docs/construction/ebay.md
@@ -1,0 +1,86 @@
+# Electronics Bay Construction
+
+## E-Bay Specifications
+
+| Component | Description |
+|-----------|-------------|
+| Diameter | 98mm (4") |
+| Design | Single threaded rod (lighter than dual) |
+| Access | Wing nut removal, sled slides out |
+| Sled | Glued to one bulkhead |
+
+## Design Advantages
+
+Apogee's e-bay design features:
+
+- Fewer parts = lighter weight
+- Faster field setup
+- Shorter pre-flight checklist
+- Easy electronics access
+
+## Assembly Steps
+
+### 1. Bulkhead Preparation
+
+- Sand edges of plywood bulkheads
+- Remove any laser char
+
+### 2. Stop Rings
+
+- Glue stop rings to inner tube
+- These position the sled correctly
+
+### 3. Threaded Rod Rails
+
+- Glue alignment rails for threaded rod
+- Ensures straight rod path
+
+### 4. Sled Assembly
+
+- Glue sled plate to bulkhead with single slot
+- Add internal fillets for strength
+- Pre-drill holes for altimeter mounting
+
+### 5. Switch Band
+
+- Install switch band on coupler tube
+- May need to peel inner paper layer if tight fit
+- Glue centered on coupler
+
+### 6. Eyebolt Installation
+
+- Install eyebolts on both bulkheads
+- These attach to shock cords
+
+### 7. Final Assembly
+
+- Insert sled through coupler
+- Secure with washer and wing nut
+- Test fit in airframe
+
+## Electronics Mounting
+
+!!! note "Altimeter Installation"
+    The sled provides mounting holes for:
+    
+    - Dual deployment altimeter
+    - GPS tracker
+    - Wiring routing between sides
+
+### Recommended Altimeters
+
+- Featherweight Blue Jay (compact, affordable)
+- Missileworks RRC3
+- Eggtimer Quantum
+- PerfectFlite StratoLogger
+
+## Wiring Considerations
+
+- Route wires through sled holes
+- Keep wiring short to reduce snag risk
+- Use CAT5 cable for power runs
+- Strategic hot glue to prevent vibration issues
+
+## Build Photos
+
+*Photos to be added during construction*

--- a/docs/construction/fins.md
+++ b/docs/construction/fins.md
@@ -1,0 +1,60 @@
+# Fin Construction
+
+## Fin Specifications
+
+| Property | Value |
+|----------|-------|
+| Quantity | 3 |
+| Material | Birch plywood |
+| Profile | Swept-back curved |
+| Attachment | Through-the-wall (TTW) |
+| Extends Below Tube | Yes |
+
+## Unique Fin Design
+
+The Peregrine's fins are distinctive:
+
+- Curved leading edge (reminiscent of 1950s sci-fi rockets)
+- Extend below the body tube base
+- Interlocking tab structure for alignment
+- Large surface area for stability
+
+## Construction Steps
+
+### 1. Preparation
+
+- Sand fin edges lightly
+- Test fit in body tube slots
+- Ensure interlocking structure aligns properly
+
+### 2. Tacking
+
+- Use thick CA to tack fins in position
+- Verify alignment with fin guide or laser level
+- Check all fins are parallel to centerline
+
+### 3. Internal Fillets
+
+- Apply 30-minute epoxy inside motor mount area
+- Use the Kevlar pull-out technique for rear ring access
+- Ensure contact with motor tube and centering rings
+
+### 4. External Fillets
+
+- Mix Rocketpoxy or 30-minute epoxy
+- Apply fillet material
+- Use popsicle stick to form smooth concave shape
+- Check for air bubbles at 15-minute mark
+- Clean excess with fondant ball technique
+
+## Fin Flutter Considerations
+
+At expected velocities (under Mach 0.5), fin flutter is not a concern for:
+
+- Birch plywood construction
+- Proper fillet application
+- Normal H/I motor flights
+
+## Build Photos
+
+*Photos to be added during construction*

--- a/docs/construction/motor-mount.md
+++ b/docs/construction/motor-mount.md
@@ -1,0 +1,52 @@
+# Motor Mount Construction
+
+## Specifications
+
+| Component | Value |
+|-----------|-------|
+| Motor Tube ID | 38mm |
+| Motor Tube Length | 11" (28 cm) |
+| Centering Rings | Plywood, 38mm to 98mm |
+
+## Motor Retention Options
+
+The kit does NOT include motor retention. Options:
+
+### Option 1: AeroPack Retainer (Recommended)
+
+- AeroPack 38L for LOC-style paper tubes (OD 1.630")
+- Provides professional appearance
+- Easy motor changes
+- Epoxy to aft centering ring
+
+### Option 2: Fins & Fire Retainer
+
+- Alternative to AeroPack
+- Similar functionality
+
+### Option 3: Masking Tape (Traditional)
+
+- Wrap tape around motor at tube exit
+- Simple and effective
+- Must re-tape each flight
+
+## Shock Cord Attachment
+
+The motor mount includes a Kevlar cord anchor:
+
+1. Thread Kevlar through centering ring holes
+2. Secure with epoxy
+3. Allows rear centering ring to be pulled out for internal fillet access
+
+## Long Motor Accommodation
+
+!!! note "Motor Length"
+    The motor tube is 11" long. For motors longer than the tube:
+    
+    - Remove thrust block
+    - Motor will project into parachute bay
+    - Verify adequate space for recovery gear
+
+## Build Photos
+
+*Photos to be added during construction*

--- a/docs/construction/recovery.md
+++ b/docs/construction/recovery.md
@@ -1,0 +1,80 @@
+# Recovery System
+
+## Dual Deployment Overview
+
+```mermaid
+flowchart TD
+    A[Launch] --> B[Motor Burnout]
+    B --> C[Coast to Apogee]
+    C --> D[Altimeter Fires Drogue Charge]
+    D --> E[Drogue Deploys - Fast Descent]
+    E --> F[Reach Main Deploy Altitude]
+    F --> G[Altimeter Fires Main Charge]
+    G --> H[Main Deploys - Slow Descent]
+    H --> I[Landing]
+```
+
+## Recovery Components
+
+| Component | Size | Location |
+|-----------|------|----------|
+| Drogue Parachute | 18" (45 cm) | Forward bay (nose to e-bay) |
+| Main Parachute | 48" (122 cm) | Aft bay (e-bay to fins) |
+| Chute Protectors | 12" Nomex x2 | One per bay |
+| Shock Cord (drogue) | Long, orange tubular nylon | Forward |
+| Shock Cord (main) | Short, orange tubular nylon | Aft |
+
+## Shock Cord Assignment
+
+!!! important "Cord Lengths"
+    Per Apogee instructions:
+    
+    - **Shorter cord** goes in **forward/drogue** section
+    - **Longer cord** goes with **motor mount** (discovered by reading full instructions)
+
+## Chute Protector Attachment
+
+- Attach close to tube exits
+- Allow enough slack for chute to fully clear
+- Some builders add one protector-width spacing
+
+## Parachute Attachment
+
+Use quick links for easy field changes:
+
+```
+Nose Cone Loop ─── Quick Link ─── Shock Cord ─── Quick Link ─── Drogue Chute
+                                      │
+                                E-Bay Eyebolt
+```
+
+## Single Deploy Configuration
+
+For L1 certification (recommended):
+
+1. Place main parachute in aft bay
+2. Use motor ejection charge
+3. Secure nose cone to upper tube (tape or plastic rivets)
+4. Leave drogue removed or use as backup
+
+!!! tip "Shear Pins"
+    For dual deploy after certification:
+    
+    - Use metal screws for single deploy (nose stays attached)
+    - Switch to nylon shear pins for dual deploy
+    - 2-3 shear pins typically sufficient for Peregrine
+
+## Descent Rate Calculations
+
+See [Ejection Charges](../calculations/ejection-charges.md) for sizing.
+
+Target descent rates:
+
+| Phase | Target Rate |
+|-------|-------------|
+| Drogue | 50-75 ft/s (fast but controlled) |
+| Main | 15-20 ft/s (soft landing) |
+
+## Build Photos
+
+*Photos to be added during construction*

--- a/docs/flight/checklist.md
+++ b/docs/flight/checklist.md
@@ -1,0 +1,95 @@
+# Pre-Flight Checklist
+
+## Day Before Launch
+
+- [ ] Check weather forecast
+- [ ] Charge altimeter battery
+- [ ] Verify motor availability
+- [ ] Pack all equipment
+- [ ] Review simulation predictions
+
+## Equipment Checklist
+
+### Rocket Components
+
+- [ ] Rocket (all sections)
+- [ ] Motor(s)
+- [ ] Motor retention hardware
+- [ ] Igniters and igniter clips
+- [ ] Recovery wadding (if using)
+
+### Electronics
+
+- [ ] Altimeter (charged)
+- [ ] Fresh batteries (spares)
+- [ ] E-matches (if dual deploy)
+- [ ] Black powder charges (measured)
+- [ ] Masking tape for charge cups
+
+### Recovery
+
+- [ ] Main parachute
+- [ ] Drogue parachute (if dual deploy)
+- [ ] Shock cords (inspect for damage)
+- [ ] Quick links
+- [ ] Chute protectors
+
+### Tools
+
+- [ ] Allen wrenches
+- [ ] Screwdrivers
+- [ ] Tape (masking, electrical)
+- [ ] Knife/scissors
+- [ ] Marker/pen
+
+### Safety
+
+- [ ] Safety glasses
+- [ ] First aid kit
+- [ ] Fire extinguisher (club usually provides)
+- [ ] Cell phone
+
+## On-Pad Procedure
+
+### 1. Motor Installation
+
+- [ ] Install motor in mount
+- [ ] Secure motor retention
+- [ ] Verify motor is seated correctly
+
+### 2. Recovery Prep
+
+- [ ] Fold parachute(s)
+- [ ] Attach chute protectors
+- [ ] Load recovery bays
+- [ ] Secure nose cone (tape/shear pins)
+
+### 3. Electronics (if dual deploy)
+
+- [ ] Connect e-match leads
+- [ ] Verify continuity (altimeter beeps)
+- [ ] Arm altimeter
+- [ ] Close e-bay
+- [ ] Secure rivets/shear pins
+
+### 4. Final Checks
+
+- [ ] CG location verified
+- [ ] All sections secure
+- [ ] Rail buttons/lugs clear
+- [ ] Igniter installed (last step)
+
+## Post-Flight
+
+- [ ] Photograph landing site
+- [ ] Inspect for damage
+- [ ] Download altimeter data
+- [ ] Record flight details
+- [ ] Prep for next flight or pack up
+
+## L1 Certification Specific
+
+- [ ] Notify prefect/TAP of certification attempt
+- [ ] Have membership card ready
+- [ ] Complete certification paperwork before flight
+- [ ] Witness signature after successful flight

--- a/docs/flight/log.md
+++ b/docs/flight/log.md
@@ -1,0 +1,67 @@
+# Flight Log
+
+## Flight Records
+
+*Flight entries will be added here after each flight*
+
+---
+
+### Flight Template
+
+```markdown
+## Flight #X - YYYY-MM-DD
+
+### Conditions
+| Parameter | Value |
+|-----------|-------|
+| Location | |
+| Temperature | °C |
+| Wind | mph, direction |
+| Cloud cover | |
+
+### Configuration
+| Parameter | Value |
+|-----------|-------|
+| Motor | |
+| Liftoff weight | lbs |
+| CG location | inches from nose |
+| Recovery mode | Single/Dual deploy |
+| Rail length | ft |
+
+### Flight Data
+| Parameter | Value |
+|-----------|-------|
+| Apogee | ft AGL |
+| Max velocity | ft/s |
+| Time to apogee | s |
+| Deployment altitude | ft |
+| Total flight time | s |
+
+### Results
+- [ ] Successful launch
+- [ ] Stable flight
+- [ ] Recovery deployed
+- [ ] Recovered intact
+
+### Notes
+
+
+### Photos
+
+```
+
+---
+
+## Certification Flight
+
+*Reserved for L1 certification flight record*
+
+| Parameter | Value |
+|-----------|-------|
+| Date | |
+| Location | |
+| Organization | Tripoli |
+| Witness (TAP/Prefect) | |
+| Motor used | |
+| Result | |
+| Certification # | |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,36 @@
+# Apogee Peregrine - Tripoli L1 Certification Build
+
+This documentation covers my Tripoli Level 1 certification attempt using the **Apogee Peregrine** dual deployment rocket kit.
+
+## Quick Specs
+
+| Parameter | Value |
+|-----------|-------|
+| Length | 68.8" (175 cm) |
+| Diameter | 4.0" (98mm) |
+| Dry Weight | ~5+ lbs (~2.3 kg) |
+| Motor Mount | 38mm (29mm with adapter) |
+| Fins | 3 swept-back birch plywood |
+| Recovery | Dual deployment capable |
+
+## Documentation Sections
+
+- **[Specifications](specifications/overview.md)** - Detailed rocket specifications and kit contents
+- **[Construction](construction/build-log.md)** - Build progress and techniques
+- **[Calculations](calculations/stability.md)** - Stability, ejection charges, vent holes
+- **[Simulations](simulations/openrocket.md)** - OpenRocket files and flight predictions
+- **[Flight](flight/checklist.md)** - Pre-flight checklist and flight log
+- **[Photos](photos/index.md)** - Build and flight photography
+
+## Certification Requirements
+
+For Tripoli L1 certification:
+
+- Successfully fly a rocket using an H or I impulse motor
+- Rocket must be recovered in flight-ready condition
+- Must be witnessed by a Tripoli member (TAP/Prefect)
+
+## Project Status
+
+!!! info "Current Status"
+    Build in progress - documentation being populated

--- a/docs/javascripts/mathjax.js
+++ b/docs/javascripts/mathjax.js
@@ -1,0 +1,12 @@
+window.MathJax = {
+  tex: {
+    inlineMath: [['$', '$'], ['\\(', '\\)']],
+    displayMath: [['$$', '$$'], ['\\[', '\\]']],
+    processEscapes: true,
+    processEnvironments: true
+  },
+  options: {
+    ignoreHtmlClass: '.*|',
+    processHtmlClass: 'arithmatex'
+  }
+};

--- a/docs/photos/index.md
+++ b/docs/photos/index.md
@@ -1,0 +1,39 @@
+# Photo Gallery
+
+This section contains photographs documenting the build and flight of the Peregrine.
+
+## Organization
+
+Photos are organized by category:
+
+- `kit/` - Unboxing and kit contents
+- `build/` - Construction progress
+- `finishing/` - Painting and decals
+- `flight/` - Launch and recovery photos
+
+## Adding Photos
+
+To add photos:
+
+1. Add image files to appropriate subdirectory in `docs/photos/`
+2. Reference in markdown:
+
+```markdown
+![Description](photos/category/filename.jpg)
+```
+
+## Kit Contents
+
+*Photos to be added*
+
+## Build Progress
+
+*Photos to be added*
+
+## Finished Rocket
+
+*Photos to be added*
+
+## Flight Photos
+
+*Photos to be added*

--- a/docs/simulations/motors.md
+++ b/docs/simulations/motors.md
@@ -1,0 +1,89 @@
+# Motor Selection
+
+## Motor Requirements
+
+### L1 Certification
+
+- **H class** (160.01-320 N·s) or **I class** (320.01-640 N·s)
+- Must be 18+ to purchase
+- Single motor allowed for certification attempt with club membership
+
+### Peregrine Motor Mount
+
+- Native: **38mm**
+- With adapter: **29mm** (using Aero Pack 29/38mm adapter)
+
+## Recommended Motors
+
+### 38mm Motors (Primary)
+
+| Motor | Impulse | Avg Thrust | Burn | Est. Altitude |
+|-------|---------|------------|------|---------------|
+| AeroTech H100W | 186 N·s | 100 N | 1.9s | ~800 ft |
+| AeroTech H180W | 219 N·s | 180 N | 1.2s | ~900 ft |
+| AeroTech H210 Redline | 240 N·s | 210 N | 1.1s | ~950 ft |
+| AeroTech H220T | 224 N·s | 220 N | 1.0s | ~900 ft |
+| Cesaroni H180-SK | 226 N·s | 180 N | 1.3s | ~900 ft |
+
+!!! tip "First Flight Recommendation"
+    For L1 certification, the **H180W** or **H210 Redline** are popular choices:
+    
+    - Good thrust-to-weight ratio
+    - Reasonable altitude (visible, recoverable)
+    - Proven reliability
+
+### 29mm Motors (Test Flights)
+
+With 29/38mm adapter:
+
+| Motor | Impulse | Notes |
+|-------|---------|-------|
+| AeroTech G80T | 120 N·s | Largest non-HP motor |
+| AeroTech G79W | 112 N·s | White lightning |
+| AeroTech G77R | 108 N·s | Redline (visible flame) |
+
+!!! warning "Low Impulse"
+    G motors may result in marginal rail exit velocity.
+    Check simulations before flying.
+
+## Motor Selection Criteria
+
+1. **Rail Exit Velocity** ≥ 50 ft/s
+2. **Maximum Altitude** within field boundaries
+3. **Stability** margin throughout flight
+4. **Recovery** drift within recovery area
+5. **Cost** and availability
+
+## Ejection Delay
+
+Match motor delay to time-to-apogee:
+
+| Motor Designation | Available Delays |
+|-------------------|------------------|
+| H180W-14 | 14 second |
+| H210-14 | 14 second |
+
+!!! note "Delay Adjustment"
+    AeroTech DMS motors include adjustable delay:
+    
+    - Use delay adjustment tool
+    - Match to RockSim/OpenRocket prediction
+    - Or use "Optimal Delay" from simulation
+
+## Motor Propellant Types
+
+| Code | Propellant | Characteristics |
+|------|------------|------------------|
+| W | White Lightning | White exhaust, good visibility |
+| T | Blue Thunder | Blue exhaust, some smoke |
+| R | Redline | Red flame, high visibility |
+| SK | Skidmark | Smoky (Cesaroni) |
+
+## Cost Comparison
+
+*Prices vary - check current pricing*
+
+| Motor Type | Approximate Cost |
+|------------|------------------|
+| Single Use (DMS) | $50-70 |
+| Reload (requires hardware) | $25-40 reload + hardware |

--- a/docs/simulations/openrocket.md
+++ b/docs/simulations/openrocket.md
@@ -1,0 +1,82 @@
+# OpenRocket Simulations
+
+## Design File
+
+The Peregrine design file is available from Apogee as a RockSim (.rkt) file.
+
+### Converting RockSim to OpenRocket
+
+1. Download RockSim file from Apogee product page
+2. Open OpenRocket
+3. File → Open → Select .rkt file
+4. OpenRocket imports automatically
+5. Save as .ork file
+
+!!! note "Fin Import"
+    The curved Peregrine fins import correctly via this method.
+    Manual recreation of the spline fin shape is difficult.
+
+## Simulation Parameters
+
+### Launch Site Conditions
+
+*Configure for your launch site*
+
+| Parameter | Value |
+|-----------|-------|
+| Location | TBD |
+| Altitude | TBD m ASL |
+| Temperature | TBD °C |
+| Pressure | 1013 hPa (std) |
+| Wind | TBD m/s |
+
+### Mass Override
+
+!!! important "Accurate Mass"
+    After building, weigh rocket and update:
+    
+    1. Click on Stage at top
+    2. Go to Override tab
+    3. Enter measured mass and CG
+    4. Re-run simulations
+
+## Flight Predictions
+
+### Motor: AeroTech H180W
+
+*Simulation results to be added*
+
+| Parameter | Value |
+|-----------|-------|
+| Max Altitude | TBD ft |
+| Max Velocity | TBD ft/s |
+| Max Mach | TBD |
+| Time to Apogee | TBD s |
+| Optimal Delay | TBD s |
+| Rail Exit Velocity | TBD ft/s |
+| Stability (off rod) | TBD cal |
+
+### Motor: AeroTech H100W
+
+*Simulation results to be added*
+
+### Motor: AeroTech H210 Redline
+
+*Simulation results to be added*
+
+## Graphs
+
+*Insert simulation graphs here*
+
+- Altitude vs Time
+- Velocity vs Time
+- Stability vs Time
+- Flight trajectory
+
+## OpenRocket File
+
+*Link to .ork file in repository*
+
+```
+openrocket/peregrine.ork
+```

--- a/docs/specifications/dimensions.md
+++ b/docs/specifications/dimensions.md
@@ -1,0 +1,71 @@
+# Dimensions
+
+## Overall Dimensions
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                                                                         │
+│  ◄──────────────────────── 68.8" (175 cm) ────────────────────────────► │
+│                                                                         │
+│     ╭──────╮                                                            │
+│    ╱        ╲    ┌──────────────────────────────────────────┐   ╲      │
+│   ╱   NOSE   ╲   │              BODY TUBE                   │    ╲╲╲   │
+│   ╲   CONE   ╱   │              + E-BAY                     │    ╱╱╱   │
+│    ╲        ╱    └──────────────────────────────────────────┘   ╱      │
+│     ╰──────╯                                                            │
+│                                                                         │
+│  ◄── 19.8" ──►   ◄─────────────────────────────────────────────────►   │
+│   (exposed)                                                             │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+
+                              ◄── 4.0" (98mm) ──►
+                                  (diameter)
+```
+
+## Detailed Measurements
+
+| Dimension | Imperial | Metric |
+|-----------|----------|--------|
+| Total Length | 68.8" | 175 cm |
+| Body Diameter (OD) | 4.0" | 98mm |
+| Nose Cone (exposed) | 19.8" | 50 cm |
+| Nose Cone Shape | 5:1 Ogive | - |
+| Motor Tube (ID) | 38mm | - |
+| Motor Tube Length | 11" | 28 cm |
+
+## Fin Dimensions
+
+The Peregrine features distinctive swept-back curved fins that extend below the body tube base.
+
+!!! info "Fin Geometry"
+    The curved fin profile requires freeform or spline definition in OpenRocket.
+    RockSim file from Apogee contains accurate fin geometry.
+
+| Parameter | Value |
+|-----------|-------|
+| Fin Count | 3 |
+| Material | Birch plywood |
+| Attachment | Through-the-wall (TTW) |
+| Extends Below Tube | Yes |
+
+## Electronics Bay Dimensions
+
+| Dimension | Value |
+|-----------|-------|
+| E-Bay Diameter | 98mm (4") |
+| Coupler OD | Fits 98mm body tube |
+| Sled Width | Fits inside coupler |
+
+## Recovery Bay Volumes
+
+These volumes are important for calculating ejection charges:
+
+| Bay | Location | Notes |
+|-----|----------|-------|
+| Drogue Bay | Forward (nose to e-bay) | 18" drogue + protector |
+| Main Bay | Aft (e-bay to fins) | 48" main + protector |
+
+!!! note "Volume Calculation"
+    Use RockSim or OpenRocket to calculate exact bay volumes.
+    See [Ejection Charges](../calculations/ejection-charges.md) for charge sizing.

--- a/docs/specifications/kit-contents.md
+++ b/docs/specifications/kit-contents.md
@@ -1,0 +1,83 @@
+# Kit Contents
+
+The Apogee Peregrine kit includes all components needed for a complete dual-deployment rocket build.
+
+## Airframe Components
+
+| Component | Description |
+|-----------|-------------|
+| Body Tubes | Heavy-wall kraft paper, white overwrap |
+| Coupler Tubes | For joining sections |
+| Nose Cone (PNC-98) | 5:1 ogive, polypropylene plastic |
+| Centering Rings | Aviation plywood |
+| Bulkheads | Plywood |
+
+## Fin Assembly
+
+| Component | Description |
+|-----------|-------------|
+| Fins (3) | Laser-cut birch plywood, swept-back curved shape |
+| Fin Alignment | Interlocking support structure |
+
+## Motor Mount
+
+| Component | Description |
+|-----------|-------------|
+| Motor Tube | 38mm diameter, heavy wall |
+| Centering Rings | Plywood, sized for 38mm to 98mm |
+| Thrust Block | Included (remove for longer motors) |
+
+!!! note "Motor Retention"
+    Motor retention is NOT included. Apogee recommends:
+    
+    - AeroPack 38L Engine Retainer
+    - Fins & Fire 38mm Retainer
+    - Or use masking tape (traditional method)
+
+## Electronics Bay (E-Bay)
+
+| Component | Description |
+|-----------|-------------|
+| E-Bay Tube | 98mm diameter coupler |
+| Bulkheads | Plywood with eyebolt holes |
+| Sled | Plywood mounting platform |
+| Threaded Rod | Single rod design (lighter than dual-rod) |
+| Switch Band | For arming switch mounting |
+| Hardware | Wing nut, washers, eyebolts |
+
+## Recovery System
+
+| Component | Size/Description |
+|-----------|------------------|
+| Main Parachute | 48" ripstop nylon, printed pattern |
+| Drogue Parachute | 18" ripstop nylon |
+| Shock Cord (Main) | Shorter cord, fluorescent orange tubular nylon |
+| Shock Cord (Drogue) | Longer cord, fluorescent orange tubular nylon |
+| Chute Protectors | 12" Nomex, reusable (2 included) |
+| Quick Links | For easy parachute attachment |
+
+## Finishing
+
+| Component | Description |
+|-----------|-------------|
+| Vinyl Decals | 2 full sheets (color + metallic silver) |
+| Rail Buttons | For launch rail guidance |
+| Plastic Rivets | For securing e-bay to airframe |
+
+## Not Included (Required)
+
+- Motor retention system
+- Altimeter/flight computer
+- Ejection charge canisters (for dual deploy)
+- Black powder or CO2 cartridges
+- E-matches or igniters
+- Epoxy (5-minute and 30-minute recommended)
+- Paint and primer
+- Motors
+
+## Optional Accessories
+
+- 29/38mm Motor Adapter (for test flights on G motors)
+- AeroPack Motor Retainer
+- GPS Tracker
+- Keychain camera with aerodynamic shroud

--- a/docs/specifications/materials.md
+++ b/docs/specifications/materials.md
@@ -1,0 +1,103 @@
+# Materials
+
+## Airframe Materials
+
+### Body Tubes
+
+| Property | Value |
+|----------|-------|
+| Material | Kraft paper |
+| Wall Type | Heavy wall |
+| Surface | White glassine overwrap |
+| Spiral | Tight wound |
+
+**Characteristics:**
+
+- Easy to mark with pencil
+- Tight spirals minimize filling work
+- White surface shows construction marks clearly
+- Can be reinforced with fiberglass if desired
+
+### Centering Rings & Bulkheads
+
+| Property | Value |
+|----------|-------|
+| Material | Aviation plywood |
+| Cut Method | Laser cut |
+| Finish | Requires light sanding on edges |
+
+### Fins
+
+| Property | Value |
+|----------|-------|
+| Material | Aeronautical birch plywood |
+| Cut Method | Laser cut |
+| Profile | Swept-back curved |
+| Grain | Oriented for maximum strength |
+
+## Nose Cone Material
+
+| Property | Value |
+|----------|-------|
+| Material | Polypropylene plastic |
+| Flexibility | Moderate flex (impact resistant) |
+| Paint Adhesion | Requires adhesion promoter |
+
+!!! warning "Painting Polypropylene"
+    Polypropylene does not accept paint well. Use:
+    
+    1. Clean surface thoroughly
+    2. Apply adhesion promoter (plastic primer)
+    3. Apply regular primer
+    4. Paint as normal
+
+## Recovery Materials
+
+### Parachutes
+
+| Property | Value |
+|----------|-------|
+| Material | Thin-mill ripstop nylon |
+| Feel | Soft, silk-like |
+| Shroud Lines | Double-looped at canopy |
+| Packing | Very compact |
+
+### Shock Cord
+
+| Property | Value |
+|----------|-------|
+| Type | Tubular nylon |
+| Color | Fluorescent orange |
+| Visibility | High (aids recovery) |
+
+### Chute Protectors
+
+| Property | Value |
+|----------|-------|
+| Material | Nomex cloth |
+| Size | 12" diameter |
+| Quantity | 2 (one per bay) |
+| Reusability | Fully reusable |
+
+## Recommended Construction Adhesives
+
+| Application | Recommended |
+|-------------|-------------|
+| General Assembly | 5-minute epoxy |
+| Fin Fillets | 30-minute epoxy or Rocketpoxy |
+| High-Stress Joints | JB Weld or 30-minute epoxy |
+| Motor Retainer | High-temperature epoxy (JB Weld) |
+| Quick Tacks | Thick CA (cyanoacrylate) |
+
+## Material Strengths
+
+!!! note "Construction Philosophy"
+    The Peregrine uses traditional rocketry materials:
+    
+    - Proven reliability
+    - Easy to work with
+    - Familiar to most builders
+    - Good strength-to-weight ratio
+    - Economical
+    
+    For extreme applications, tubes can be reinforced with fiberglass cloth.

--- a/docs/specifications/overview.md
+++ b/docs/specifications/overview.md
@@ -1,0 +1,60 @@
+# Apogee Peregrine Overview
+
+The Peregrine is a high-power dual-deployment rocket designed by Apogee Components. It features distinctive swept-back curved fins and is intended for fliers who already have (or are pursuing) Level 1 certification.
+
+## Key Features
+
+- **Dual Deployment Ready**: Includes electronics bay, dual parachutes, and all hardware
+- **Distinctive Fin Design**: Swept-back curved birch plywood fins extend below the base tube
+- **Large Size**: 68.8" length makes it highly visible during flight
+- **Traditional Construction**: Kraft paper tubes, plywood centering rings, wooden components
+- **Detailed Instructions**: Apogee provides comprehensive step-by-step build documentation
+
+## Primary Specifications
+
+| Specification | Value | Metric |
+|--------------|-------|--------|
+| Overall Length | 68.8" | 175 cm |
+| Body Diameter | 4.0" | 98mm |
+| Nose Cone Length | 19.8" exposed | 50 cm |
+| Nose Cone Type | 5:1 Ogive | - |
+| Dry Weight | ~5+ lbs | ~2.3+ kg |
+| Motor Mount | 38mm | - |
+| Fin Count | 3 | - |
+| Fin Material | Birch plywood | - |
+
+## Nose Cone Details
+
+The PNC-98 nose cone:
+
+- 5:1 length-to-diameter ogive shape
+- Made from polypropylene plastic (flexible, impact resistant)
+- Requires adhesion promoter before priming/painting
+- Super-strong attachment loop for shock cord
+
+## Recovery System
+
+| Component | Size |
+|-----------|------|
+| Main Parachute | 48" (122 cm) nylon |
+| Drogue Parachute | 18" (45 cm) nylon |
+| Shock Cord | Fluorescent orange tubular nylon |
+| Chute Protectors | 12" Nomex (2 included) |
+
+## Motor Recommendations
+
+### For L1 Certification (38mm motors)
+
+- AeroTech H100W
+- AeroTech H180W  
+- AeroTech H210 Redline
+- AeroTech H220T
+- Cesaroni H180
+
+### Test Flights (29mm with adapter)
+
+- AeroTech G80T (max non-HP motor)
+- Various G motors with 29/38mm adapter
+
+!!! warning "Certification Advice"
+    Apogee recommends NOT using dual deployment for L1/L2 certification flights. Use single deployment with motor ejection for simplicity.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,65 @@
+site_name: Apogee Peregrine L1 Certification
+site_description: Documentation for Tõnu's Tripoli L1 certification rocket build
+site_author: Tõnu Onu
+
+theme:
+  name: material
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - search.highlight
+    - content.code.copy
+  palette:
+    - scheme: default
+      primary: deep orange
+      accent: orange
+
+markdown_extensions:
+  - pymdownx.arithmatex:
+      generic: true
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - admonition
+  - pymdownx.details
+  - attr_list
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+
+extra_javascript:
+  - javascripts/mathjax.js
+  - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
+
+nav:
+  - Home: index.md
+  - Rocket Specifications:
+    - Overview: specifications/overview.md
+    - Kit Contents: specifications/kit-contents.md
+    - Dimensions: specifications/dimensions.md
+    - Materials: specifications/materials.md
+  - Construction:
+    - Build Log: construction/build-log.md
+    - Motor Mount: construction/motor-mount.md
+    - Fins: construction/fins.md
+    - Electronics Bay: construction/ebay.md
+    - Recovery System: construction/recovery.md
+  - Calculations:
+    - Stability: calculations/stability.md
+    - Ejection Charges: calculations/ejection-charges.md
+    - Vent Holes: calculations/vent-holes.md
+    - Rail Exit Velocity: calculations/rail-exit.md
+  - Simulations:
+    - OpenRocket Results: simulations/openrocket.md
+    - Motor Selection: simulations/motors.md
+  - Flight:
+    - Pre-flight Checklist: flight/checklist.md
+    - Flight Log: flight/log.md
+  - Photos: photos/index.md

--- a/openrocket/.gitkeep
+++ b/openrocket/.gitkeep
@@ -1,0 +1,2 @@
+# OpenRocket simulation files go here
+# Download .rkt from Apogee and convert to .ork


### PR DESCRIPTION
## Overview

Sets up MkDocs Material documentation framework for the L1 certification Peregrine build.

## What's Included

### Documentation Framework
- MkDocs Material theme with navigation tabs and search
- MathJax integration for LaTeX formulas (ejection charges, stability, rail exit velocity)
- Mermaid support for diagrams (recovery sequence flowchart)

### Peregrine Specifications (from Apogee website research)
| Specification | Value |
|--------------|-------|
| Length | 68.8" (175 cm) |
| Diameter | 4.0" (98mm) |
| Dry Weight | ~5+ lbs |
| Motor Mount | 38mm (29mm with adapter) |
| Nose Cone | 5:1 ogive, 19.8" exposed, polypropylene |
| Fins | 3 swept-back birch plywood |
| Recovery | 48" main, 18" drogue, Nomex protectors |
| E-Bay | 98mm, single threaded rod design |

### Documentation Structure
```
docs/
├── index.md                     # Overview with quick specs
├── specifications/
│   ├── overview.md              # Kit description, features
│   ├── kit-contents.md          # Complete parts list
│   ├── dimensions.md            # Measurements with ASCII diagram
│   └── materials.md             # Material properties, adhesives
├── construction/
│   ├── build-log.md             # Chronological build entries
│   ├── motor-mount.md           # Motor retention options
│   ├── fins.md                  # Curved fin installation
│   ├── ebay.md                  # Electronics bay assembly
│   └── recovery.md              # Dual deploy system with flowchart
├── calculations/
│   ├── stability.md             # CP/CG formulas
│   ├── ejection-charges.md      # Black powder sizing
│   ├── vent-holes.md            # Static port calculations
│   └── rail-exit.md             # Minimum velocity/rail length
├── simulations/
│   ├── openrocket.md            # Simulation setup and results
│   └── motors.md                # Motor comparison table
├── flight/
│   ├── checklist.md             # Pre-flight procedures
│   └── log.md                   # Flight record template
└── photos/
    └── index.md                 # Photo gallery structure
```

### Additional Files
- `CLAUDE.md` - Project guidelines and build instructions
- `mkdocs.yml` - Site configuration
- `openrocket/.gitkeep` - Placeholder for simulation files

## To Build Locally

```bash
pip install mkdocs-material
mkdocs serve
```

## To Deploy

```bash
mkdocs gh-deploy
```

This will publish to GitHub Pages at `https://tonuonu.github.io/MyLevel1Peregrine/`

## Next Steps After Merge

1. Enable GitHub Pages (Settings → Pages → Source: gh-pages branch)
2. Add OpenRocket .ork file converted from Apogee's RockSim file
3. Add build photos as construction progresses
4. Fill in TBD values after measuring actual built components