### PR TITLE
Add kit identification and packaging discrepancies

### DIFF
--- a/docs/specifications/kit-contents.md
+++ b/docs/specifications/kit-contents.md
@@ -2,6 +2,21 @@
 
 The Apogee Peregrine kit includes all components needed for a complete dual-deployment rocket build.
 
+## Kit Identification
+
+| Info | Value |
+|------|-------|
+| Kit Number | 04998 |
+| Face Card P/N | 39101 |
+| Barcode | 656779049988 |
+| Age Rating | 18+ |
+
+!!! note "Packaging vs Website Discrepancies"
+    | Item | Packaging | Website/Actual |
+    |------|-----------|----------------|
+    | Skill Level | 4 | 3 |
+    | Height | "Over 65"" | 68.8" (175 cm) |
+
 ## Airframe Components
 
 | Component | Description |


### PR DESCRIPTION
Adds Kit Identification section to kit-contents.md with:

- Kit number, face card P/N, barcode, age rating
- Note documenting discrepancies between packaging and website:
  - Skill Level: packaging says 4, website says 3
  - Height: packaging says "Over 65\"", actual is 68.8"