### PR TITLE
Update docs for L2 certification (22 Feb 2026)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,23 @@
-# Peregrine L1
+# Peregrine
 
-**L1 CERTIFIED** ✓ — 24 January 2026, Enköping, Sweden
+**L2 CERTIFIED** ✓ — 22 February 2026, Enköping, Sweden
 
-Documentation for my Tripoli Level 1 certification using the Apogee Peregrine dual deployment rocket, named **SIPSIK** after the beloved Estonian cartoon character.
+Documentation for my Tripoli Level 1 and Level 2 certification rocket build using the Apogee Peregrine dual deployment kit, named **SIPSIK** after the beloved Estonian cartoon character.
 
 **📖 Documentation Site: [tonuonu.github.io/MyLevel1Peregrine](https://tonuonu.github.io/MyLevel1Peregrine/)**
+
+## L2 Certification Flight
+
+| | |
+|---|---|
+| **Date** | 22 February 2026 |
+| **Location** | Enköping, Sweden (SMRK) |
+| **Motor** | AeroTech J350 |
+| **Weight** | 3100 g |
+| **Expected Altitude** | 1100 m |
+| **Recovery** | Dual deploy, 18" + 48" electronic (CATS Vega) |
+| **Certifying Authority** | Rolf Örell (TRA# 3728) |
+| **Result** | **CERTIFIED** |
 
 ## L1 Certification Flight
 
@@ -17,14 +30,6 @@ Documentation for my Tripoli Level 1 certification using the Apogee Peregrine du
 | **Recovery** | Motor ejection, single chute |
 | **Certifying Authority** | Rolf Örell (TRA# 3728) |
 | **Result** | **CERTIFIED** |
-
-## Next: L2 Certification
-
-| | |
-|---|---|
-| **Written Exam** | ✅ Passed (27 Jan 2026) |
-| **Target Flight** | 7 February 2026 (tentative) |
-| **Motor** | AeroTech J420R-14A (ordered) |
 
 ## Repository Contents
 

--- a/docs/certification/index.md
+++ b/docs/certification/index.md
@@ -41,6 +41,7 @@
 | CG | 115 cm from nose tip |
 | CP | 130 cm from nose tip |
 | Expected altitude | 1100 m |
+| Actual altitude | ~1000 m (estimated, flight log pending) |
 
 ### Recovery Configuration
 

--- a/docs/certification/index.md
+++ b/docs/certification/index.md
@@ -1,7 +1,8 @@
-# L1 Certification
+# Certification
 
-## Status: CERTIFIED ✓
+## Status: L2 CERTIFIED ✓
 
+**Tripoli Level 2 - Certified 22 February 2026**
 **Tripoli Level 1 - Certified 24 January 2026**
 
 ## Tripoli Membership
@@ -12,8 +13,70 @@
 |-------|-------|
 | Organization | Tripoli Rocketry Association |
 | Member Number | 38105 |
-| Status | L1 Certified |
+| Status | L2 Certified |
 | Expires | November 2026 |
+
+---
+
+## L2 Certification Flight
+
+### Flight Details
+
+| Parameter | Value |
+|-----------|-------|
+| Date | 22 February 2026 |
+| Location | Enköping, Sweden |
+| Organization | SMRK (Swedish Model Rocket Club) |
+| Motor | AeroTech J350 |
+| Result | **Successful** |
+
+### Rocket Configuration
+
+| Parameter | Value |
+|-----------|-------|
+| Kit | Apogee Peregrine |
+| Length | 175 cm |
+| Diameter | 100 mm |
+| Liftoff weight | 3100 g |
+| CG | 115 cm from nose tip |
+| CP | 130 cm from nose tip |
+| Expected altitude | 1100 m |
+
+### Recovery Configuration
+
+Dual deployment with electronic ejection via CATS Vega:
+
+- **Drogue**: 18" parachute at apogee
+- **Main**: 48" parachute at lower altitude
+
+### Electronics
+
+| Device | Purpose |
+|--------|---------|
+| CATS Vega | Flight computer, dual deployment control |
+
+### L2 Written Examination
+
+| Field | Value |
+|-------|-------|
+| Passed | 27 January 2026 |
+| Certificate # | 2343 |
+
+![L2 Written Exam Certificate](../photos/l2_written_exam_certificate.jpg)
+
+### Certifying Authority
+
+| Field | Value |
+|-------|-------|
+| Name | Rolf Örell |
+| TRA # | 3728 |
+| Role | Tripoli Prefect |
+
+### Official Documents
+
+[Download L2 Certification Form (PDF)](../photos/l2_certification_form.pdf)
+
+---
 
 ## L1 Certification Flight
 
@@ -75,21 +138,24 @@ Originally planned dual deployment with electronic ejection. Pivoted to motor ej
 
 Rolf is one of Tripoli's [Lifetime Members](https://tripoli.clubexpress.com/content.aspx?page_id=22&club_id=795696&module_id=494497) and reportedly the first Tripoli Prefect in Europe.
 
+### Official Documents
+
+[Download L1 Certification Form (PDF)](../photos/l1_certification_form.pdf)
+
+---
+
 ## Acknowledgments
 
-Special thanks to those who helped make this certification possible:
+Special thanks to those who helped make both certifications possible:
 
-- **Rolf Örell** - Certifying authority, signed the certificate
-- **Peter Steen** - Launch support and guidance  
+- **Rolf Örell** - Certifying authority for L1 and L2
+- **Peter Steen** - Launch support and guidance
 - **Anton Vannesjö** - Launch support and guidance
 
 ## Lessons Learned
 
+### L1
 1. **Know your tools** - The Aerotech delay adjustment tool has a +2s disk; understand all components before launch day
 2. **Swedish launch requirements** - Ejection charge testing required; plan for motor ejection as fallback
 3. **Weight matters** - Additional electronics increased weight beyond budget, reducing altitude by ~30%
 4. **Motor procurement** - Cannot transport motors on Tallink passenger ferries (blanket ban on dangerous substances); must purchase locally in Sweden or find alternative transport
-
-## Official Documents
-
-[Download L1 Certification Form (PDF)](../photos/l1_certification_form.pdf)

--- a/docs/certification/index.md
+++ b/docs/certification/index.md
@@ -20,6 +20,12 @@
 
 ## L2 Certification Flight
 
+### Flight Video
+
+<video controls width="100%">
+  <source src="../photos/l2_certification_flight.mp4" type="video/mp4">
+</video>
+
 ### Flight Details
 
 | Parameter | Value |

--- a/docs/certification/l2-planning.md
+++ b/docs/certification/l2-planning.md
@@ -43,6 +43,7 @@ Apogee Peregrine "SIPSIK" in full L2 configuration:
 | CG | 115 cm from nose tip |
 | CP | 130 cm from nose tip |
 | Expected altitude | 1100 m |
+| Actual altitude | ~1000 m (estimated, flight log not yet downloaded) |
 | Recovery | Dual deploy, 18" + 48" electronic |
 | Flight computer | CATS Vega |
 

--- a/docs/certification/l2-planning.md
+++ b/docs/certification/l2-planning.md
@@ -13,11 +13,13 @@
 
 ## Motor
 
-Originally planned AeroTech J420R-14A, flew with AeroTech J350.
+Originally ordered an AeroTech J420R-14A reload from [Space Rocket Technology](https://www.spacerockettechnology-shop.de/) (Germany) in late January, to be shipped to Peter Steen in Sweden. A DHL shipping label (CD042602182DE) was created on 4 February 2026, but the package was never actually picked up — no tracking movement after three weeks.
+
+Rolf Örell had some ~25-year-old AeroTech J350 reloads in stock and offered one for the certification flight. It worked perfectly.
 
 | Parameter | Value |
 |-----------|-------|
-| Motor | AeroTech J350 |
+| Motor | AeroTech J350 (~25-year-old reload from Rolf Örell) |
 | Casing | 38/720 (38mm, 720 N-s max) |
 
 ### Hardware

--- a/docs/certification/l2-planning.md
+++ b/docs/certification/l2-planning.md
@@ -1,71 +1,57 @@
-# L2 Certification Planning
+# L2 Certification
 
-## Status: IN PROGRESS
+## Status: CERTIFIED ✓
 
-Target date: **7 February 2026** (tentative, pending motor delivery confirmation)
+**Certified 22 February 2026** at Enköping, Sweden.
 
-## Written Exam
+## Timeline
 
-✅ **Passed** - 27 January 2026, Certificate #2343
-
-![L2 Written Exam Certificate](../photos/l2_written_exam_certificate.jpg)
+| Date | Milestone |
+|------|-----------|
+| 27 January 2026 | L2 written exam passed (Certificate #2343) |
+| 22 February 2026 | L2 certification flight — **Successful** |
 
 ## Motor
 
-### Ordered
+Originally planned AeroTech J420R-14A, flew with AeroTech J350.
 
-| Item | Source | Ship To | Status |
-|------|--------|---------|--------|
-| [AeroTech J420R-14A](https://www.spacerockettechnology-shop.de/en/J420R-14A.html) | Space Rocket Technology (Germany) | Peter Steen (Sweden) | Awaiting shipping confirmation |
-
-Motor specs:
-- Total impulse: 658 N-s (full J)
-- Average thrust: 420 N
-- Burn time: 1.6 s
-- Total weight: 635 g
-- Propellant: Redline
+| Parameter | Value |
+|-----------|-------|
+| Motor | AeroTech J350 |
+| Casing | 38/720 (38mm, 720 N-s max) |
 
 ### Hardware
 
-Purchased Aerotech reloadable motor casings from Rolf Örell:
+Aerotech reloadable motor casings purchased from Rolf Örell:
 
 | Casing | Diameter | Max Impulse | Use |
 |--------|----------|-------------|-----|
-| **38/720** | 38mm | 720 N-s | J420R, future J motors |
-| **29/180** | 29mm | 180 N-s | H128W, future H motors |
-
-## Logistics
-
-### Uncertainty
-
-- Motor shipping confirmation not yet received
-- Ferry tickets not booked (prices increasing daily)
-- Cannot commit to travel until motor delivery confirmed
-
-### Contingencies
-
-If J420R doesn't arrive in time:
-1. Postpone to next SMRK launch date
-2. Check local Swedish availability (Peter/Rolf/Anton)
-3. Check Swedish retailers
-
-### Transport
-
-Same as L1: car on Tallinn-Stockholm ferry, drive to Enköping.
-
-Reminder: rocket motors cannot be transported on Tallink passenger ferries (blanket ban). Motor must be purchased/shipped within Sweden.
+| **38/720** | 38mm | 720 N-s | J350 (L2), future J motors |
+| **29/180** | 29mm | 180 N-s | H128W (L1), future H motors |
 
 ## Rocket Configuration
 
-Using same Apogee Peregrine "SIPSIK" rocket in L2 configuration:
-- Full length with e-bay (175 cm)
-- 38mm motor mount (no adapter needed for J420R)
-- Dual deployment with CATS Vega
+Apogee Peregrine "SIPSIK" in full L2 configuration:
+
+| Parameter | Value |
+|-----------|-------|
+| Length | 175 cm |
+| Diameter | 100 mm |
+| Liftoff weight | 3100 g |
+| CG | 115 cm from nose tip |
+| CP | 130 cm from nose tip |
+| Expected altitude | 1100 m |
+| Recovery | Dual deploy, 18" + 48" electronic |
+| Flight computer | CATS Vega |
 
 ## Requirements
 
 Per Tripoli L2 certification:
 - [x] Current L1 certification
 - [x] Pass L2 written exam
-- [ ] Successfully fly and recover rocket using J, K, or L motor
-- [ ] Witnessed by Prefect, TAP, or Board member
+- [x] Successfully fly and recover rocket using J, K, or L motor
+- [x] Witnessed by Prefect, TAP, or Board member
+
+## Logistics
+
+Same as L1: car on Tallinn-Stockholm ferry, drive to Enköping. Motor purchased/shipped within Sweden (Tallink ferry ban on dangerous substances).

--- a/docs/flight/data/generate_charts.py
+++ b/docs/flight/data/generate_charts.py
@@ -30,11 +30,25 @@ Record Types:
     128 (0x80) - BARO: int32 (pressure Pa) - 12 bytes total
     256 (0x100) - FILTERED: 2x float32 (altitude m, velocity m/s) - 16 bytes total
 
+Sensor Information:
+-------------------
+IMU: STMicroelectronics LSM6DSO32 (from CATS firmware lsm6dso32.hpp)
+  - Configured at ±32g range (AccelerometerFs::kFs32G)
+  - Sensitivity: 0.976 mg/LSB = 1024 LSB/g (from datasheet)
+  - 16-bit output: ±32768 LSB maps to ±32g
+  - ODR: 104 Hz
+
+Barometer: MS5607 (temperature-compensated pressure sensor)
+  - Altitude formula uses hardcoded 15°C (TEMPERATURE_0 constant)
+  - Does not use actual measured temperature for altitude calculation
+
 Known Issues / TODO:
 --------------------
-1. Liftoff doesn't start exactly at 0m AGL - there's sensor settling time
-2. Velocity shows 0 during descent in some phases - FILTERED data issue
-3. Accelerometer scale factor is approximate (~29700 LSB/g)
+1. Liftoff doesn't start exactly at 0m AGL - sensor settling time
+2. Velocity shows 0 during descent in some phases - FILTERED data limitation
+3. Raw accelerometer data in log has unexpected offset (~-28662 LSB at rest vs expected ~-1024 LSB)
+   - May be firmware-specific encoding or uncalibrated offset
+   - Needs investigation in CATS firmware data_processing.cpp
 4. Temperature not compensated in altitude (hardcoded 15°C in firmware)
 
 Flight Parameters (hardcoded - update for other flights):

--- a/docs/flight/data/generate_charts.py
+++ b/docs/flight/data/generate_charts.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""
+Flight #1 Telemetry Chart Generator
+====================================
+
+Parses CATS Vega binary flight log (fl001.cfl) and generates flight profile charts.
+
+Usage:
+    python3 generate_charts.py
+
+Requirements:
+    pip install matplotlib numpy
+
+Input:
+    fl001.cfl - CATS Vega binary flight log (same directory)
+
+Output:
+    ../flight1_charts.png - 4-panel flight profile chart
+
+CATS Vega Binary Format (v3.0.2):
+---------------------------------
+Header: 6 bytes (magic + version)
+Records: variable length, each starts with:
+    - timestamp: uint32 (milliseconds since boot)
+    - record_type: uint32
+
+Record Types:
+    32 (0x20)  - RAW: 6x int16 (ax, ay, az, gx, gy, gz) - 20 bytes total
+    64 (0x40)  - IMU: 6x int16 - 20 bytes total  
+    128 (0x80) - BARO: int32 (pressure Pa) - 12 bytes total
+    256 (0x100) - FILTERED: 2x float32 (altitude m, velocity m/s) - 16 bytes total
+
+Known Issues / TODO:
+--------------------
+1. Liftoff doesn't start exactly at 0m AGL - there's sensor settling time
+2. Velocity shows 0 during descent in some phases - FILTERED data issue
+3. Accelerometer scale factor is approximate (~29700 LSB/g)
+4. Temperature not compensated in altitude (hardcoded 15°C in firmware)
+
+Flight Parameters (hardcoded - update for other flights):
+---------------------------------------------------------
+- liftoff_ts: 278340 ms (timestamp when rocket left pad)
+- Motor: AeroTech H128W-14A
+- Parachute: 48" diameter
+"""
+
+import struct
+import os
+import sys
+
+# Check for required libraries
+try:
+    import matplotlib.pyplot as plt
+    import numpy as np
+except ImportError:
+    print("Missing required libraries. Install with:")
+    print("  pip install matplotlib numpy")
+    sys.exit(1)
+
+
+def parse_cats_log(filepath):
+    """
+    Parse CATS Vega binary flight log.
+    
+    Returns:
+        dict with 'filtered' and 'raw' record lists
+    """
+    with open(filepath, 'rb') as f:
+        data = f.read()
+    
+    # Skip 6-byte header
+    pos = 6
+    filtered_records = []
+    raw_records = []
+    
+    while pos < len(data) - 24:
+        try:
+            ts = struct.unpack('<I', data[pos:pos+4])[0]
+            rec_type = struct.unpack('<I', data[pos+4:pos+8])[0]
+            
+            # Only process records in flight time window
+            if 270000 < ts < 350000:
+                if rec_type == 256:  # FILTERED
+                    alt = struct.unpack('<f', data[pos+8:pos+12])[0]
+                    vel = struct.unpack('<f', data[pos+12:pos+16])[0]
+                    filtered_records.append((ts, alt, vel))
+                    pos += 16
+                elif rec_type == 32:  # RAW
+                    vals = struct.unpack('<6h', data[pos+8:pos+20])
+                    raw_records.append((ts, vals))
+                    pos += 20
+                elif rec_type == 64:  # IMU
+                    pos += 20
+                elif rec_type == 128:  # BARO
+                    pos += 12
+                else:
+                    pos += 4
+            else:
+                pos += 4
+        except:
+            pos += 4
+    
+    return {
+        'filtered': filtered_records,
+        'raw': raw_records
+    }
+
+
+def generate_charts(records, output_path, liftoff_ts=278340):
+    """
+    Generate 4-panel flight profile chart.
+    
+    Args:
+        records: dict from parse_cats_log()
+        output_path: where to save PNG
+        liftoff_ts: timestamp of liftoff in milliseconds
+    """
+    # Convert filtered data to arrays
+    f_times = np.array([(r[0] - liftoff_ts) / 1000 for r in records['filtered']])
+    f_alt = np.array([r[1] for r in records['filtered']])
+    f_vel = np.array([r[2] for r in records['filtered']])
+    
+    # Convert raw accelerometer data
+    r_times = np.array([(r[0] - liftoff_ts) / 1000 for r in records['raw']])
+    ax_raw = np.array([r[1][0] for r in records['raw']])
+    
+    # Calculate descent rate from altitude change (after chute inflated)
+    descent_mask = (f_times > 12) & (f_times < 22)
+    if descent_mask.sum() > 2:
+        t1, t2 = f_times[descent_mask][0], f_times[descent_mask][-1]
+        a1, a2 = f_alt[descent_mask][0], f_alt[descent_mask][-1]
+        descent_rate = (a1 - a2) / (t2 - t1)
+    else:
+        descent_rate = 5.7  # fallback
+    
+    # Flight events (adjust these for other flights)
+    events = {
+        'liftoff': 0,
+        'burnout': 1.33,
+        'apogee': 5.68,
+        'deploy': 10.79,
+        'landing': 22.86
+    }
+    
+    # Create figure
+    fig, axes = plt.subplots(2, 2, figsize=(14, 10))
+    
+    # Panel 1: Altitude profile
+    ax1 = axes[0, 0]
+    ax1.plot(f_times, f_alt, 'b-', linewidth=2)
+    ax1.fill_between(f_times, 0, f_alt, alpha=0.2)
+    ax1.axvline(x=events['liftoff'], color='green', linewidth=2, label='Liftoff')
+    ax1.axvline(x=events['burnout'], color='orange', linewidth=2, label=f"Burnout (+{events['burnout']}s)")
+    ax1.axvline(x=events['apogee'], color='red', linewidth=2, label=f"Apogee (+{events['apogee']}s)")
+    ax1.axvline(x=events['deploy'], color='purple', linewidth=2, label=f"Deploy (+{events['deploy']}s)")
+    ax1.axvline(x=events['landing'], color='brown', linewidth=2, label=f"Landing (+{events['landing']}s)")
+    ax1.set_xlabel('Time from Liftoff (seconds)', fontsize=11)
+    ax1.set_ylabel('Altitude AGL (meters)', fontsize=11)
+    ax1.set_title('Altitude Profile', fontsize=12, fontweight='bold')
+    ax1.legend(loc='upper right', fontsize=8)
+    ax1.grid(True, alpha=0.3)
+    ax1.set_xlim(-1, 24)
+    ax1.set_ylim(0, 160)
+    
+    apogee_alt = f_alt.max()
+    ax1.annotate(f'Apogee\n{apogee_alt:.1f} m', 
+                 xy=(events['apogee'], apogee_alt), xytext=(7, 145),
+                 fontsize=10, ha='left', arrowprops=dict(arrowstyle='->', color='red'))
+    
+    # Panel 2: Velocity profile
+    ax2 = axes[0, 1]
+    ax2.plot(f_times, f_vel, 'g-', linewidth=2)
+    ax2.axhline(y=0, color='gray', linestyle='--', alpha=0.5)
+    ax2.axvline(x=events['liftoff'], color='green', linewidth=2)
+    ax2.axvline(x=events['burnout'], color='orange', linewidth=2)
+    ax2.axvline(x=events['apogee'], color='red', linewidth=2)
+    ax2.axvline(x=events['deploy'], color='purple', linewidth=2)
+    ax2.set_xlabel('Time from Liftoff (seconds)', fontsize=11)
+    ax2.set_ylabel('Velocity (m/s)', fontsize=11)
+    ax2.set_title('Velocity Profile', fontsize=12, fontweight='bold')
+    ax2.grid(True, alpha=0.3)
+    ax2.set_xlim(-1, 24)
+    ax2.annotate(f'Under canopy\n~{descent_rate:.1f} m/s descent', 
+                 xy=(16, f_vel[(f_times > 15) & (f_times < 17)].mean()),
+                 xytext=(17, -3), fontsize=9,
+                 arrowprops=dict(arrowstyle='->', color='purple'))
+    
+    # Panel 3: Boost phase detail
+    ax3 = axes[1, 0]
+    mask = (f_times >= -0.1) & (f_times <= 2.5)
+    ax3.plot(f_times[mask], f_vel[mask], 'g-', linewidth=2, label='Velocity')
+    ax3_alt = ax3.twinx()
+    ax3_alt.plot(f_times[mask], f_alt[mask], 'b-', linewidth=2, alpha=0.7, label='Altitude')
+    ax3.axvline(x=events['liftoff'], color='green', linewidth=2, label='Liftoff')
+    ax3.axvline(x=events['burnout'], color='orange', linewidth=2, label='Burnout')
+    ax3.set_xlabel('Time from Liftoff (seconds)', fontsize=11)
+    ax3.set_ylabel('Velocity (m/s)', fontsize=11, color='green')
+    ax3_alt.set_ylabel('Altitude (m)', fontsize=11, color='blue')
+    ax3.set_title('Boost Phase - Motor Burn (AeroTech H128W-14A)', fontsize=12, fontweight='bold')
+    ax3.grid(True, alpha=0.3)
+    ax3.legend(loc='center right', fontsize=8)
+    
+    # Panel 4: Deployment & chute inflation
+    ax4 = axes[1, 1]
+    mask_r = (r_times >= 10.0) & (r_times <= 14.0)
+    mask_f = (f_times >= 10.0) & (f_times <= 14.0)
+    
+    # Scale accelerometer for visualization
+    ax_baseline = ax_raw[mask_r][-100:].mean() if mask_r.sum() > 100 else ax_raw[mask_r].mean()
+    ax_display = -(ax_raw[mask_r] - ax_baseline) / 7000 * 20
+    
+    ax4.plot(f_times[mask_f], f_alt[mask_f], 'b-', linewidth=2, label='Altitude')
+    ax4.plot(r_times[mask_r], 80 + ax_display, 'r-', linewidth=1, alpha=0.7, label='Accelerometer (scaled)')
+    ax4.axvline(x=events['deploy'], color='purple', linewidth=2)
+    ax4.annotate('Ejection charge fires', xy=(events['deploy'], 90), xytext=(10.3, 95),
+                 fontsize=9, ha='right', arrowprops=dict(arrowstyle='->', color='purple'))
+    ax4.annotate('48" chute\ninflation\noscillations', xy=(11.5, 85), xytext=(12.5, 90),
+                 fontsize=9, arrowprops=dict(arrowstyle='->', color='red'))
+    ax4.set_xlabel('Time from Liftoff (seconds)', fontsize=11)
+    ax4.set_ylabel('Altitude (m) / Accel (scaled)', fontsize=11)
+    ax4.set_title('Deployment Event - Parachute Inflation', fontsize=12, fontweight='bold')
+    ax4.legend(loc='upper right', fontsize=8)
+    ax4.grid(True, alpha=0.3)
+    
+    plt.suptitle('MyLevel1Peregrine Flight #1 - L1 Certification\nAeroTech H128W-14A | 141.6m Apogee | 48" Parachute', 
+                 fontsize=14, fontweight='bold')
+    plt.tight_layout()
+    plt.savefig(output_path, dpi=150, bbox_inches='tight')
+    print(f"Chart saved to: {output_path}")
+
+
+def print_flight_summary(records, liftoff_ts=278340):
+    """Print flight timeline and statistics."""
+    f_times = np.array([(r[0] - liftoff_ts) / 1000 for r in records['filtered']])
+    f_alt = np.array([r[1] for r in records['filtered']])
+    f_vel = np.array([r[2] for r in records['filtered']])
+    
+    print("\n" + "="*50)
+    print("FLIGHT #1 SUMMARY")
+    print("="*50)
+    print(f"Motor: AeroTech H128W-14A")
+    print(f"Apogee: {f_alt.max():.1f} m at T+{f_times[np.argmax(f_alt)]:.2f}s")
+    print(f"Max velocity: {f_vel.max():.1f} m/s at T+{f_times[np.argmax(f_vel)]:.2f}s")
+    print(f"\nTimeline:")
+    print(f"  T+0.00s    Liftoff")
+    print(f"  T+1.33s    Motor burnout")
+    print(f"  T+5.68s    Apogee (141.6m)")
+    print(f"  T+10.79s   Ejection charge fires")
+    print(f"  T+10.8-12s Chute inflation")
+    print(f"  T+22.86s   Landing (CATS stops logging)")
+
+
+if __name__ == '__main__':
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    input_file = os.path.join(script_dir, 'fl001.cfl')
+    output_file = os.path.join(script_dir, '..', 'flight1_charts.png')
+    
+    if not os.path.exists(input_file):
+        print(f"Error: {input_file} not found")
+        sys.exit(1)
+    
+    print(f"Parsing: {input_file}")
+    records = parse_cats_log(input_file)
+    print(f"Found {len(records['filtered'])} filtered records, {len(records['raw'])} raw records")
+    
+    print_flight_summary(records)
+    generate_charts(records, output_file)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,8 @@
-# Peregrine L1
+# Peregrine
 
 <div class="hero" markdown>
 
-**Tripoli Level 1 Certified** ✓
+**Tripoli Level 2 Certified** ✓
 
 Apogee Peregrine dual deployment rocket • Tripoli #38105 • Estonia → Sweden
 
@@ -13,41 +13,45 @@ Apogee Peregrine dual deployment rocket • Tripoli #38105 • Estonia → Swede
 <div class="grid" markdown>
 
 <div class="card" markdown>
-### Rocket Specs
+### L2 Flight
 | | |
 |---|---|
-| **Length** | 175 cm |
-| **Diameter** | 100 mm |
-| **Weight** | 2350 g |
-| **Motor** | H128W-14A |
-| **Recovery** | Motor ejection |
+| **Date** | 22 Feb 2026 |
+| **Location** | Enköping, Sweden |
+| **Motor** | J350 |
+| **Weight** | 3100 g |
+| **Recovery** | Dual deploy |
 </div>
 
 <div class="card" markdown>
-### Certification Flight
+### L1 Flight
 | | |
 |---|---|
 | **Date** | 24 Jan 2026 |
 | **Location** | Enköping, Sweden |
+| **Motor** | H128W-14A |
 | **Altitude** | 140.8 m |
-| **Witness** | Rolf Örell |
+| **Recovery** | Motor ejection |
 </div>
 
 <div class="card" markdown>
 ### Status
-<span class="status status-complete">L1 CERTIFIED</span>
+<span class="status status-complete">L2 CERTIFIED</span>
 
-Tripoli #38105  
-L2 written exam: **Passed**
+Tripoli #38105
+L1: 24 Jan 2026
+L2: 22 Feb 2026
 </div>
 
 </div>
 
 ---
 
-## Mission Accomplished
+## L2 Certified
 
-This rocket, named **SIPSIK** after the beloved Estonian cartoon character, successfully flew on 24 January 2026 at Enköping, Sweden, achieving Tripoli L1 certification.
+This rocket, named **SIPSIK** after the beloved Estonian cartoon character, achieved Tripoli L2 certification on 22 February 2026 at Enköping, Sweden, flying on an AeroTech J350 with dual deployment recovery via CATS Vega.
+
+L1 certification was achieved one month earlier on 24 January 2026 at the same location.
 
 ### The Story Behind Sipsik
 
@@ -59,8 +63,8 @@ This site documents the complete build and certification process:
 
 | Section | Description |
 |---------|-------------|
-| [**Certification**](certification/index.md) | L1 achieved, L2 exam passed |
-| [**Flight Log**](flight/log.md) | Flight #1 data and analysis |
+| [**Certification**](certification/index.md) | L1 and L2 achieved |
+| [**Flight Log**](flight/log.md) | Flight data and analysis |
 | [**Specifications**](specifications/overview.md) | Detailed rocket specs |
 | [**Construction**](construction/build-log.md) | Build progress and techniques |
 | [**Calculations**](calculations/stability.md) | Stability, ejection charges |
@@ -70,23 +74,13 @@ This site documents the complete build and certification process:
 
 ## Acknowledgments
 
-- **Rolf Örell** (TRA# 3728) — Certifying authority, first European Tripoli Prefect
+- **Rolf Örell** (TRA# 3728) — Certifying authority for both L1 and L2, first European Tripoli Prefect
 - **Peter Steen** — Launch support and guidance
 - **Anton Vannesjö** — Launch support and guidance
-
-## What's Next
-
-**L2 certification flight** — target 7 February 2026 (tentative)
-
-- Written exam passed (27 Jan 2026, Certificate #2343)
-- Motor ordered: AeroTech J420R-14A
-- Hardware: 38/720 and 29/180 casings purchased from Rolf
-
-See [L2 Planning](certification/l2-planning.md) for details.
 
 ---
 
 <small>
-[Tõnu Samuel](https://www.linkedin.com/in/tonusamuel/) • Software engineer • Tallinn, Estonia  
+[Tõnu Samuel](https://www.linkedin.com/in/tonusamuel/) • Software engineer • Tallinn, Estonia
 Build: [BUILD_COMMIT_HASH](BUILD_COMMIT_URL) (BUILD_DATE)
 </small>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
-site_name: Peregrine L1
-site_description: Tõnu's Tripoli L1 certification rocket build documentation
+site_name: Peregrine
+site_description: Tõnu's Tripoli L1 & L2 certification rocket build documentation
 site_author: Tõnu Samuel
 site_url: https://tonuonu.github.io/MyLevel1Peregrine/
 
@@ -99,8 +99,8 @@ nav:
   - Home: index.md
   - Configurations: configurations.md
   - Certification:
-    - L1 Certified: certification/index.md
-    - L2 Planning: certification/l2-planning.md
+    - Overview: certification/index.md
+    - L2 Certified: certification/l2-planning.md
   - Rocket Specifications:
     - Overview: specifications/overview.md
     - Kit Contents: specifications/kit-contents.md


### PR DESCRIPTION
## L2 Certified! 🎉

Updates documentation to reflect successful Tripoli Level 2 certification flight on 22 February 2026 at Enköping, Sweden.

### Flight Details
- **Motor**: AeroTech J350 (changed from originally planned J420R)
- **Weight**: 3100 g
- **Recovery**: Dual deploy, 18" + 48" electronic (CATS Vega)
- **Expected altitude**: 1100 m
- **Certifying Authority**: Rolf Örell (TRA# 3728)

### Changes
- **README.md**: Updated status to L2 CERTIFIED, added L2 flight table
- **docs/index.md**: Updated hero section, cards, and content for L2
- **docs/certification/index.md**: Added full L2 flight section with video embed, updated status header
- **docs/certification/l2-planning.md**: Converted from planning page to completed certification page
- **docs/photos/l2_certification_flight.mp4**: L2 flight video (25 MB)
- **mkdocs.yml**: Updated site name from "Peregrine L1" to "Peregrine", updated nav labels

### Not yet included
- L2 certification form PDF
- L2 flight photos
- Updated Tripoli card image (now showing Level 2)