### PR TITLE
Post-L2 cleanup + L3 planning

### DIFF
--- a/docs/certification/index.md
+++ b/docs/certification/index.md
@@ -51,16 +51,19 @@
 
 ### Recovery Configuration
 
-Dual deployment with electronic ejection via CATS Vega:
+Dual deployment was required by the 500m landing radius constraint. Simulations showed that with main-only recovery from ~1000m, any wind above 4 m/s would carry the rocket beyond the allowed radius.
 
-- **Drogue**: 18" parachute at apogee
-- **Main**: 48" parachute at lower altitude
+Triple-redundant ejection system:
+
+- **Electronic #1 (CATS Vega)**: 18" drogue parachute at apogee
+- **Electronic #2 (CATS Vega)**: 48" main parachute at lower altitude
+- **Motor backup**: Original 14s factory delay left unmodified as independent safety charge
 
 ### Electronics
 
 | Device | Purpose |
 |--------|---------|
-| CATS Vega | Flight computer, dual deployment control |
+| CATS Vega | Flight computer, dual deployment control (2 pyro channels) |
 
 ### L2 Written Examination
 
@@ -148,6 +151,21 @@ Rolf is one of Tripoli's [Lifetime Members](https://tripoli.clubexpress.com/cont
 ### Official Documents
 
 [Download L1 Certification Form (PDF)](../photos/l1_certification_form.pdf)
+
+---
+
+## What's Next: L3
+
+L1 and L2 served as verification that the fundamentals were understood correctly. L3 is a different challenge — building a rocket from scratch rather than using a kit.
+
+| Requirement | Status |
+|-------------|--------|
+| Current L2 certification | ✓ |
+| TAP member #1 | Rolf Örell (confirmed) |
+| TAP member #2 | TBD |
+| Scratch-built rocket | Design phase |
+| Documentation package | Not started |
+| Review flight | Not scheduled |
 
 ---
 

--- a/docs/certification/l3-planning.md
+++ b/docs/certification/l3-planning.md
@@ -1,0 +1,161 @@
+# L3 Certification Planning
+
+## Status: DESIGN PHASE
+
+L1 and L2 were verification that fundamentals were understood correctly — kit-based flights with known parameters. L3 is a different challenge: designing and building a rocket from scratch.
+
+## Requirements
+
+Per Tripoli L3 certification:
+
+- [x] Current L2 certification
+- [ ] Written project report reviewed by 2 TAP members before flight
+- [ ] Scratch-built rocket (no kits)
+- [ ] Successfully fly and recover using M, N, or O motor
+- [ ] Witnessed and approved by 2 TAP members
+
+### TAP Committee
+
+| Role | Name | Status |
+|------|------|--------|
+| TAP member #1 | Rolf Örell (TRA# 3728) | Confirmed |
+| TAP member #2 | TBD | Rolf to introduce |
+
+## Motor Selection
+
+### Sizing Constraints
+
+M-class motors are the minimum for L3. These are not available below 75mm diameter. 98mm is also an option but drives a larger rocket. Since high power is not the goal (just meeting requirements), 75mm is preferred to keep the rocket as small as practical.
+
+### Motor Type: Single-Use
+
+Single-use (disposable casing) rather than reloadable, for several reasons:
+
+- No need to purchase expensive reloadable casing hardware
+- No borrowed equipment at risk in a CATO
+- Simpler preparation on launch day
+- Acceptable cost for a one-off certification flight
+
+### Candidate Motors
+
+| Motor | Diameter | Total Impulse | Notes |
+|-------|----------|--------------|-------|
+| TBD | 75mm | M-class (5120-10240 N-s) | Research needed |
+
+98mm single-use motors are a fallback if 75mm options are insufficient.
+
+## Airframe Design
+
+### Minimum Dimensions
+
+The 75mm motor mount sets the minimum body tube inner diameter. With typical wall thickness, this means a minimum airframe OD of approximately 80-85mm, though a larger airframe (e.g. 100-120mm) may be needed for stability, recovery hardware, and electronics bay space.
+
+### Construction Approach
+
+Scratch-built — all structural components designed and fabricated, not from a kit.
+
+## Fin Can Design
+
+### Design Tool: OpenSCAD
+
+OpenSCAD chosen for fin can design because:
+
+- C++-like syntax (familiar programming paradigm)
+- Parametric design — dimensions driven by variables
+- Direct export to 3MF for 3D printing
+- Proven workflow from PeregrineFin and PeregrineFinCan75 projects
+
+### 3D Printing: Bambu P1S
+
+| Constraint | Value |
+|-----------|-------|
+| Printer | Bambu P1S (standard, not Plus) |
+| Max print height | 250mm (with AMS) |
+| Max print area | 256 × 256 mm |
+
+The 250mm height limit means the fin can body must be split into two or more rings that are bonded together. Fins are printed separately and bonded to the assembled can.
+
+### Multi-Part Assembly Strategy
+
+For a 75mm motor fin can:
+
+1. **Fin can body**: Split into 2+ cylindrical rings (each ≤250mm tall), bonded together
+2. **Fins**: Printed individually, bonded to assembled can
+3. **Joints**: Designed with alignment features (pins, keys, or overlapping sections)
+
+This avoids printing any single part that exceeds the printer's build volume.
+
+### Material: Spectrum PC CF
+
+Polycarbonate with carbon fiber fill, chosen after evaluating multiple materials:
+
+| Property | PC CF Advantage |
+|----------|----------------|
+| Temperature resistance | High — survives motor heat proximity |
+| Toughness | High impact resistance |
+| Cold weather | Does not become brittle (important for Swedish winter launches) |
+| Stiffness | CF filler increases modulus, helps with fin flutter |
+| Warping | CF filler reduces shrinkage anisotropy — the main problem with pure PC |
+
+**Pure PC experience**: Printing large components from straight PC always produced some warping despite trying all common countermeasures (enclosure, bed adhesion, annealing, etc.). Spectrum PC CF largely solves this.
+
+**Trade-off**: CF filler slightly reduces impact resistance compared to pure PC, but the increased stiffness is beneficial for flutter resistance.
+
+**Printing notes**:
+
+- Requires hardened steel nozzle (CF is abrasive)
+- Print settings: 70% infill (consistent with PeregrineFinCan experience)
+- Enclosure recommended (Bambu P1S has enclosure)
+
+## Fin Flutter Analysis
+
+### The Challenge
+
+Fin flutter is the critical structural concern for L3. M-class motors produce significantly higher velocities than the J-class used for L2. Flutter occurs when aerodynamic forces couple with fin structural modes, and can destroy fins in milliseconds.
+
+### Key Variables
+
+- **Fin thickness**: Thicker = stiffer = higher flutter speed
+- **Chord length**: Shorter chord helps
+- **Span**: Shorter span helps (but reduces stability)
+- **Material modulus**: Higher = better. PC CF is stiffer than pure PC
+- **Airspeed**: Must analyze at maximum expected velocity (likely near burnout)
+
+### Mitigation Strategies
+
+1. **Material selection**: PC CF provides higher elastic modulus than most printable materials
+2. **Carbon rod reinforcement**: Proven approach from PeregrineFin v0.7.0 (two 2.2mm channels at 25% and 60% chord). Same technique can scale to L3 fins
+3. **Geometry optimization**: Shorter span, adequate thickness, appropriate taper ratio
+4. **Conservative design**: Target flutter margin well above expected max velocity
+
+### Previous Analysis Reference
+
+PeregrineFin v0.7.0 analysis: span 137mm, area 23222mm², safety factor 1.65 at 10° AoA, flutter-safe to K-class motors with carbon rod reinforcement. L3 fin design must exceed this analysis for M-class speeds.
+
+## Documentation Package
+
+Tripoli L3 requires a comprehensive written project report. Planned sections:
+
+- [ ] Project overview and objectives
+- [ ] Stability analysis (CP/CG calculations, margin)
+- [ ] Structural analysis (fin flutter, airframe loads)
+- [ ] Recovery system design (dual deploy, redundancy)
+- [ ] Electronics and avionics
+- [ ] Construction documentation with photos
+- [ ] Ground testing results
+- [ ] Flight simulation results
+- [ ] Safety analysis
+
+### Repository
+
+This documentation will live in this repo initially. May move to a separate repository if the L3 project scope warrants it.
+
+## Open Questions
+
+1. Specific 75mm single-use M motor selection
+2. Airframe material and diameter
+3. Nose cone — 3D printed or purchased?
+4. Recovery system design (likely similar to L2: dual deploy with CATS Vega)
+5. Second TAP member
+6. Launch site — Enköping (SMRK) or elsewhere?
+7. Timeline

--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -13,7 +13,7 @@ The Apogee Peregrine is designed for dual-deployment but can be flown in simplif
 | Level | Configuration | Recovery | Rocket Length |
 |-------|--------------|----------|---------------|
 | **L1** | Full length, no e-bay deployment | Motor ejection | 175 cm |
-| **L2** | Full length, dual deploy | Electronic dual-deploy | 175 cm |
+| **L2** | Full length, dual deploy | Electronic dual-deploy + motor backup | 175 cm |
 
 ## L1 Configuration (as flown)
 
@@ -50,17 +50,21 @@ Removing e-bay deployment function moves risk profile. See [OpenRocket Analysis]
 - CATS Vega flight computer controlling deployment
 - 18" drogue parachute (upper section)
 - 48" main parachute (lower section)
+- Motor delay charge (14s, unmodified) as safety backup
 
 ### Recovery Sequence
 1. Motor burns out
 2. Rocket coasts to apogee
-3. **Apogee:** Flight computer fires drogue charge
+3. **Apogee:** Flight computer fires drogue charge (electronic #1)
 4. Drogue deploys, fast descent (~15-20 m/s)
-5. **Lower altitude:** Flight computer fires main charge
+5. **Lower altitude:** Flight computer fires main charge (electronic #2)
 6. Main chute deploys, slow descent (~5 m/s)
 7. Rocket lands close to pad
 
+Motor's original 14s delay charge left unmodified as a third, independent backup ejection source.
+
 ### Why Dual Deployment
+- **Required by 500m landing radius constraint** — simulations showed that with main-only recovery from ~1000m, any wind above 4 m/s would carry the rocket beyond the allowed radius
 - Smaller landing footprint
 - Reduced wind drift
 - What Peregrine is designed for
@@ -74,7 +78,9 @@ Removing e-bay deployment function moves risk profile. See [OpenRocket Analysis]
 | CATS Vega | Data logging only | ✓ Controls deployment |
 | Drogue chute | ❌ None | ✓ 18" at apogee |
 | Main chute | ✓ 48" | ✓ 48" at lower altitude |
-| Deployment | Motor delay | Electronic |
+| Electronic charges | ❌ None | ✓ 2× black powder |
+| Motor backup charge | ✓ Primary deployment | ✓ 14s safety backup |
+| Deployment | Motor delay | Electronic + motor backup |
 | Nose ballast | ✓ Included | ✓ Included |
 
 ## Flight Parameters

--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -4,24 +4,25 @@
 
 The Apogee Peregrine is designed for dual-deployment but can be flown in simplified configuration.
 
-!!! success "L1 Certification Complete"
-    **Actual L1 flight (24 Jan 2026):** Full-length configuration (175cm), motor ejection recovery. See [Certification](certification/index.md) for details.
+!!! success "L1 & L2 Certification Complete"
+    **L2 flight (22 Feb 2026):** Full-length configuration (175cm), dual deploy electronic recovery (CATS Vega). See [Certification](certification/index.md) for details.
+    **L1 flight (24 Jan 2026):** Full-length configuration (175cm), motor ejection recovery.
 
-### Planned Configurations
+### Configurations Flown
 
 | Level | Configuration | Recovery | Rocket Length |
 |-------|--------------|----------|---------------|
-| **L1** | Minimal | Motor ejection | 126 cm |
-| **L2** | Full | Electronic dual-deploy | 175 cm |
+| **L1** | Full length, no e-bay deployment | Motor ejection | 175 cm |
+| **L2** | Full length, dual deploy | Electronic dual-deploy | 175 cm |
 
-## L1 Certification Configuration
+## L1 Configuration (as flown)
 
-**Goal:** Simple, reliable certification flight
+**Flight:** 24 January 2026
 
 ### Hardware
-- Shortened airframe (no e-bay section)
+- Full-length airframe with e-bay (carried CATS Vega for logging only)
 - Single 48" main parachute
-- Motor ejection delay (no electronics)
+- Motor ejection delay
 - Nose ballast for stability (~300-600g epoxy)
 
 ### Recovery Sequence
@@ -32,75 +33,58 @@ The Apogee Peregrine is designed for dual-deployment but can be flown in simplif
 5. Rocket descends under single parachute
 
 ### Why This Configuration
-- Fewer failure modes
-- No electronics to malfunction
+- Fewer failure modes for first certification
+- Swedish safety rules required ejection charge testing — motor ejection as fallback
 - Traditional L1 approach
 - Proves basic HPR competency
 
 ### Stability Challenge
-Removing e-bay section moves CP forward → rocket becomes unstable without nose ballast. See [OpenRocket Analysis](../simulations/openrocket.md).
+Removing e-bay deployment function moves risk profile. See [OpenRocket Analysis](../simulations/openrocket.md).
 
-## L2 Certification Configuration
+## L2 Configuration (as flown)
 
-**Goal:** Demonstrate dual-deployment competency
+**Flight:** 22 February 2026
 
 ### Hardware
 - Full airframe with electronics bay
-- CATS Vega flight computer
+- CATS Vega flight computer controlling deployment
 - 18" drogue parachute (upper section)
 - 48" main parachute (lower section)
-- Redundant deployment charges
 
 ### Recovery Sequence
 1. Motor burns out
 2. Rocket coasts to apogee
 3. **Apogee:** Flight computer fires drogue charge
 4. Drogue deploys, fast descent (~15-20 m/s)
-5. **~300m AGL:** Flight computer fires main charge
+5. **Lower altitude:** Flight computer fires main charge
 6. Main chute deploys, slow descent (~5 m/s)
 7. Rocket lands close to pad
 
 ### Why Dual Deployment
 - Smaller landing footprint
 - Reduced wind drift
-- Required skill for L2 certification
 - What Peregrine is designed for
 
 ## Component Summary
 
 | Component | L1 Config | L2 Config |
 |-----------|-----------|-----------|
-| Body tube | Shortened | Full length |
-| Electronics bay | ❌ Removed | ✓ Installed |
-| CATS Vega | ❌ Not used | ✓ Controls deployment |
+| Body tube | Full length | Full length |
+| Electronics bay | ✓ Installed (logging only) | ✓ Controls deployment |
+| CATS Vega | Data logging only | ✓ Controls deployment |
 | Drogue chute | ❌ None | ✓ 18" at apogee |
-| Main chute | ✓ 48" | ✓ 48" at 300m |
+| Main chute | ✓ 48" | ✓ 48" at lower altitude |
 | Deployment | Motor delay | Electronic |
-| Nose ballast | ✓ Required | Optional |
-
-## Upgrade Path
-
-After L1 certification:
-
-1. Re-install electronics bay section
-2. Install CATS Vega on e-bay sled
-3. Wire pyro channels to deployment charges
-4. Add drogue parachute to upper section
-5. Configure flight computer events
-6. Test deployment on ground
-7. Fly L2 certification
+| Nose ballast | ✓ Included | ✓ Included |
 
 ## Flight Parameters
 
-| Parameter | L1 Config | L2 Config |
-|-----------|-----------|-----------|
-| Rocket mass (no motor) | ~2100g* | ~1900g |
-| Length | 126 cm | 175 cm |
-| Stability | ~1.0 cal* | 3.69 cal |
-| Motor | H128W | H or I class |
-| Expected altitude | ~235m | ~400-600m |
-
-*With nose ballast
+| Parameter | L1 (actual) | L2 (actual) |
+|-----------|-------------|-------------|
+| Rocket mass (no motor) | ~2350g (liftoff) | ~3100g (liftoff) |
+| Length | 175 cm | 175 cm |
+| Motor | H128W-14A | J350 |
+| Apogee | 141.6 m | ~1000 m (estimated) |
 
 ## References
 

--- a/docs/flight/log.md
+++ b/docs/flight/log.md
@@ -23,9 +23,16 @@
 | Liftoff weight | 3100 g |
 | CG location | 115 cm from nose tip |
 | CP location | 130 cm from nose tip |
-| Recovery mode | Dual deploy (electronic, CATS Vega) |
-| Drogue | 18" at apogee |
-| Main | 48" at lower altitude |
+| Recovery mode | Dual deploy (electronic, CATS Vega) + motor backup |
+| Drogue | 18" at apogee (electronic) |
+| Main | 48" at lower altitude (electronic) |
+| Motor delay | 14s factory (unmodified, backup safety charge) |
+
+### Recovery Design
+
+Dual deployment was required by the 500m landing radius constraint. Simulations showed that with main-only recovery from ~1000m, any wind above 4 m/s would carry the rocket beyond the allowed radius.
+
+Triple-redundant ejection: two electronic black powder charges via CATS Vega (drogue at apogee, main at altitude), plus the motor's original 14s delay charge left unmodified as a safety backup.
 
 ### Flight Data
 

--- a/docs/flight/log.md
+++ b/docs/flight/log.md
@@ -4,6 +4,64 @@
 
 ---
 
+## Flight #2 - 2026-02-22 (L2 Certification)
+
+### Conditions
+
+| Parameter | Value |
+|-----------|-------|
+| Location | Enköping, Sweden |
+| Weather | Winter |
+| Event | SMRK Launch Day |
+
+### Configuration
+
+| Parameter | Value |
+|-----------|-------|
+| Motor | AeroTech J350 (~25-year-old reload from Rolf Örell) |
+| Casing | 38/720 |
+| Liftoff weight | 3100 g |
+| CG location | 115 cm from nose tip |
+| CP location | 130 cm from nose tip |
+| Recovery mode | Dual deploy (electronic, CATS Vega) |
+| Drogue | 18" at apogee |
+| Main | 48" at lower altitude |
+
+### Flight Data
+
+| Parameter | Value |
+|-----------|-------|
+| Expected altitude | 1100 m |
+| Actual altitude | ~1000 m (estimated, flight log pending) |
+
+Flight log not yet downloaded from CATS Vega.
+
+### Results
+
+- [x] Successful launch
+- [x] Stable flight
+- [x] Dual deployment worked
+- [x] Recovered intact
+- [x] **L2 CERTIFICATION ACHIEVED**
+
+### Motor Story
+
+Originally ordered an AeroTech J420R-14A from Space Rocket Technology (Germany). DHL shipping label created 4 February but the package was never picked up — no tracking movement after three weeks. Rolf Örell had some ~25-year-old AeroTech J350 reloads in stock and offered one. It worked perfectly.
+
+### Certification
+
+| Field | Value |
+|-------|-------|
+| Certification | Tripoli L2 |
+| Certifying Authority | Rolf Örell (TRA# 3728) |
+| Flyer | Tõnu Samuel (TRA# 38105) |
+
+### Flight Video
+
+See [L2 Certification](../certification/index.md#l2-certification-flight) for video.
+
+---
+
 ## Flight #1 - 2026-01-24 (L1 Certification)
 
 ### Conditions
@@ -71,13 +129,3 @@ See [Flight #1 Analysis](flight1-analysis.md) for detailed telemetry and recomme
 ### Photos
 
 Launch photo and recovery photo with Liza holding "SIPSIK" rocket - see certification documentation.
-
----
-
-## Future Flights
-
-### Planned: L2 Certification Flight
-
-- L2 written exam passed (27 January 2026, Certificate #2343)
-- Motor class: J, K, or L required
-- Location: Sweden (motor procurement constraint)

--- a/docs/specifications/overview.md
+++ b/docs/specifications/overview.md
@@ -43,8 +43,14 @@ The PNC-98 nose cone:
 
 ## Motor Recommendations
 
-### For L1 Certification (38mm motors)
+### For L2 Certification (38mm J motors)
 
+- AeroTech J350 (used for SIPSIK L2 flight)
+- AeroTech J420R
+
+### For L1 Certification (38mm H motors, or 29mm with adapter)
+
+- AeroTech H128W (used for SIPSIK L1 flight)
 - AeroTech H100W
 - AeroTech H180W  
 - AeroTech H210 Redline
@@ -56,5 +62,5 @@ The PNC-98 nose cone:
 - AeroTech G80T (max non-HP motor)
 - Various G motors with 29/38mm adapter
 
-!!! warning "Certification Advice"
-    Apogee recommends NOT using dual deployment for L1/L2 certification flights. Use single deployment with motor ejection for simplicity.
+!!! note "Certification Note"
+    Apogee recommends single deployment with motor ejection for L1 certification for simplicity. SIPSIK used motor ejection for L1 and dual deployment (CATS Vega) for L2 — both successful.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Peregrine
-site_description: Tõnu's Tripoli L1 & L2 certification rocket build documentation
+site_description: Tõnu's Tripoli L1, L2 & L3 certification rocket build documentation
 site_author: Tõnu Samuel
 site_url: https://tonuonu.github.io/MyLevel1Peregrine/
 
@@ -101,6 +101,7 @@ nav:
   - Certification:
     - Overview: certification/index.md
     - L2 Certified: certification/l2-planning.md
+    - L3 Planning: certification/l3-planning.md
   - Rocket Specifications:
     - Overview: specifications/overview.md
     - Kit Contents: specifications/kit-contents.md


### PR DESCRIPTION
## Post-L2 Documentation Cleanup + L3 Planning

Several pages still had L1-only or future-tense L2 content after PR #26. This cleans them up, adds L2 flight details, and starts L3 planning documentation.

### L2 Cleanup

- **docs/flight/log.md**: Added Flight #2 entry for L2 certification. Added recovery design rationale (500m radius constraint, wind simulation, triple-redundant ejection). Removed stale "Future Flights / Planned: L2" section.
- **docs/configurations.md**: Updated callout to show both L1 & L2 complete. Changed all sections from future-tense to past-tense (as-flown). Added 500m radius constraint, triple redundancy details, motor backup. Removed "Upgrade Path" section. Updated Flight Parameters table with actual values.
- **docs/certification/index.md**: Updated L2 recovery section with 500m radius rationale, triple-redundant ejection (2× electronic + motor backup at 14s). Added "What's Next: L3" section with requirements checklist.
- **docs/specifications/overview.md**: Added J350 and J420R to motor recommendations. Changed certification warning admonition to a note reflecting actual experience.

### L3 Planning

- **docs/certification/l3-planning.md**: New page covering L3 design decisions and rationale:
  - 75mm single-use M motor (minimum size, no expensive reloadable hardware at risk)
  - OpenSCAD fin can design, split into multiple parts for Bambu P1S (250mm max height)
  - Spectrum PC CF filament (solves pure PC warping, cold-weather tough, high stiffness for flutter)
  - Fin flutter analysis approach (critical at M-class speeds, carbon rod reinforcement channels)
  - TAP committee (Rolf confirmed, second TBD)
  - Documentation package requirements
- **mkdocs.yml**: Added L3 Planning to nav, updated site description to include L3

### Manual action needed

- **GitHub repo description** still says "Things related to my L1 certification attempt on Apogee Peregrine rocket" — update via Settings → General.