### PR TITLE
L3 planning: flight progression, L1000W motor, custom FC

### DIFF
--- a/docs/certification/l3-design-document.md
+++ b/docs/certification/l3-design-document.md
@@ -44,7 +44,7 @@ Tripoli Level 3 high-power certification using a scratch-built rocket with a sin
 | Dry weight (no motor) | TBD |
 | Liftoff weight (with motor) | TBD |
 | Motor | AeroTech M1350W-PS (75mm, 5178 N-s) |
-| Recovery | Dual deploy, dual redundant electronics, dual-half bayonet spring release |
+| Recovery | Dual deploy, dual redundant electronics, servo-actuated spring release (mechanism TBD) |
 | Expected altitude | TBD |
 | Number of fins | TBD |
 | Fin material | Spectrum PC CF (3D printed polycarbonate + carbon fiber) |
@@ -55,7 +55,8 @@ Tripoli Level 3 high-power certification using a scratch-built rocket with a sin
 - Progressive flight testing on J and L motors before cert flight
 - 3D printed fin can in PC CF with carbon rod reinforcement for flutter resistance
 - Dual redundant electronics as required by Tripoli L3 rules
-- Symmetric dual-half bayonet spring release — one design, two identical halves, true independent redundancy
+- Servo-actuated spring release instead of black powder ejection charges — mechanism under evaluation (dual-half bayonet or hinged door)
+- Symmetric design: identical parts for both redundancy halves to simplify manufacturing and spares
 - Single-use motor to avoid reloadable hardware risk
 
 ---
@@ -161,7 +162,25 @@ For pre-certification test flights:
 
 *TODO: Decide based on airframe layout and CG analysis.*
 
-### 2.9 Rail Guides
+### 2.9 Servo and Battery Enclosures in Parachute Bay
+
+The separation servos and their batteries must be located near the separation joints, which are inside the parachute storage bays. To prevent parachutes and shock cords from snagging on electronics hardware:
+
+**Wall-hugging enclosure concept**: A 3D printed fairing mounts the servo and battery flush against the inner tube wall. The enclosure has a smooth, snag-free outer surface facing inward, so the parachute slides past without catching. Essentially a streamlined bump on the inside of the body tube.
+
+| Parameter | Value |
+|-----------|-------|
+| Material | Spectrum PC CF (same as other printed parts) |
+| Contents per enclosure | 1 servo + 1 battery (or battery located elsewhere with wiring routed through) |
+| Enclosures per joint | 2 (one per FC system, 180° apart) |
+| Total enclosures | 4 (2 joints × 2 per joint) |
+| Design | Parametric OpenSCAD, matched to tube ID curvature |
+| Mounting | Bonded or mechanically fastened to tube wall |
+| Outer surface | Smooth, radiused edges, no exposed screws or wires |
+
+*TODO: Determine whether battery is co-located with servo in the enclosure or kept in the main e-bay with wiring routed to the servo. Co-location is simpler (shorter wires, fewer failure points) but adds mass in the parachute bay.*
+
+### 2.10 Rail Guides
 
 | Parameter | Value |
 |-----------|-------|
@@ -200,8 +219,9 @@ For pre-certification test flights:
 | Drogue parachute | TBD size | 1 | TBD |
 | Main parachute | TBD size | 1 | TBD |
 | Separation springs | TBD | TBD per joint | TBD |
-| Bayonet half (printed) | Spectrum PC CF, identical part | 2 per joint (4 total for dual deploy) | Printed by candidate |
-| Servos (separation) | TBD | 1 per bayonet half (4 total) | TBD |
+| Separation mechanism parts (printed) | Spectrum PC CF, identical parts | 2 per joint (4 total) | Printed by candidate |
+| Servo wall-hugging enclosures (printed) | Spectrum PC CF, matched to tube ID | 4 total (2 per joint) | Printed by candidate |
+| Servos (separation) | TBD | 4 total (1 per mechanism half) | TBD |
 | Tether cord (mechanism retention) | TBD | As needed | TBD |
 
 ### 3.3 Electronics
@@ -229,21 +249,21 @@ For pre-certification test flights:
 
 ### 4.1 Recovery Architecture
 
-Dual deployment using symmetric dual-half bayonet release mechanisms with spring separation, controlled by dual redundant electronics:
+Dual deployment using servo-actuated spring release mechanisms, controlled by dual redundant electronics:
 
 | Event | Altitude | Device | Action |
 |-------|----------|--------|--------|
-| Apogee | Apogee detection | Primary FC + Backup FC | Either servo releases its bayonet half → spring separates body → drogue deploys |
-| Main | TBD (e.g., 300m AGL) | Primary FC + Backup FC | Either servo releases its bayonet half → spring separates body → main deploys |
+| Apogee | Apogee detection | Primary FC + Backup FC | Either servo releases its mechanism half → spring pushes parachute out → drogue deploys |
+| Main | TBD (e.g., 300m AGL) | Primary FC + Backup FC | Either servo releases its mechanism half → spring pushes parachute out → main deploys |
 
 ### 4.2 Separation Mechanism Concept
 
 Instead of black powder ejection charges, separation is achieved mechanically:
 
-1. **Springs** are preloaded between body sections during assembly, providing separation force
-2. **Dual-half bayonet** holds the sections together against the spring preload during flight
-3. **Servos** release the bayonet halves on command from the flight computer
-4. Once either half is released, the remaining half cannot hold against the spring force alone, and the sections separate
+1. **Springs** are preloaded behind the parachute during assembly, providing deployment force
+2. **Retention mechanism** (two identical halves) holds the sections together against the spring preload during flight
+3. **Servos** release the mechanism halves on command from the flight computer
+4. Once either half is released, the remaining half cannot hold against the spring force alone, and the parachute is pushed out
 
 **Advantages over BP charges**:
 
@@ -252,11 +272,15 @@ Instead of black powder ejection charges, separation is achieved mechanically:
 - No hot gas near parachutes — no Nomex protectors needed
 - Clean separation — no soot, no pressure spike
 
-### 4.3 Selected Mechanism: Symmetric Dual-Half Bayonet
+### 4.3 Separation Mechanism Candidates
+
+Two leading candidates are under evaluation. Both share the same core principle: two identical halves per joint, each controlled by one FC system, either half's release alone causes separation. The selection will be made after prototyping and discussion with Rolf.
+
+#### Option A: Symmetric Dual-Half Bayonet
 
 The bayonet joint is split into two identical halves, positioned 180° apart. Each half is an independent latch controlled by its own servo and FC system.
 
-#### Operating Principle
+**Operating principle:**
 
 ```
     LOCKED STATE                    EITHER HALF RELEASED
@@ -269,92 +293,138 @@ The bayonet joint is split into two identical halves, positioned 180° apart. Ea
     └──────────┘                    └──────────┘
 ```
 
-- **Locked**: Both bayonet halves (H1, H2) engaged. Together they carry full flight loads (axial thrust, drag, bending)
-- **Released**: Either servo releases its half. One half alone cannot resist the spring preload → sections separate
-- Each half is designed to carry approximately 50% of the axial load when both are engaged, but is deliberately unable to resist the full spring force alone
+- **Locked**: Both bayonet halves engaged. Together they carry full flight loads
+- **Released**: Either servo releases its half. One half alone cannot resist the spring preload → sections separate axially
+- Each half carries ~50% of axial load when both engaged, but cannot resist spring force alone
 
-#### Key Design Properties
+**Advantages:**
 
-| Property | Value |
-|----------|-------|
-| Number of halves per joint | 2 (identical parts) |
-| Halves per separation event | 2 (drogue joint + main joint) |
-| Total bayonet halves | 4 (2 joints × 2 halves) |
-| Servos total | 4 (one per half) |
-| Parts to design | **1** (same part used everywhere) |
-| FC #1 controls | Half A at drogue joint + Half A at main joint |
-| FC #2 controls | Half B at drogue joint + Half B at main joint |
+- Full axial separation — body sections push apart completely
+- Bayonet lugs are strong load-bearing surfaces
+- One part design, print four copies
 
-#### Redundancy Analysis
+**Concerns:**
+
+- Lug geometry is the critical design parameter — must hold flight loads with two halves but release under spring force with one half. Narrow design window
+- Must not creep under vibration — needs detent or servo holding torque
+- Servo and battery must be housed inside parachute bay (wall-hugging enclosure, see section 2.9)
+- Bayonet parts stay in the bay after release — potential tangle with parachute. Tethering and routing needed
+
+#### Option B: Hinged Door
+
+A hatch/door section at each separation joint, with hinge pins on two opposing sides (180° apart). Each FC controls one hinge pin. Springs behind the parachute push it out through the opened door.
+
+**Operating principle:**
+
+```
+    LOCKED STATE               ONE PIN PULLED           BOTH PINS PULLED
+    ┌──────────┐               ┌──────────┐             ┌──────────┐
+    │  Body    │               │  Body    │             │  Body    │
+    │ P1 door P2│              │    door⟋  │            │   ____   │
+    │          │               │  swings   │             │  open    │
+    └──────────┘               │  open on  │             │  door    │
+                               │  P1 hinge │             │  detached│
+                               └──────────┘             └──────────┘
+    P1, P2 = hinge pins        P2 removed →             Both removed →
+    Both locked                door swings on P1         door free, springs
+                               Springs push chute out    push chute out
+```
+
+- **Locked**: Both hinge pins inserted. Door is held firmly closed. Pins carry flight loads in shear
+- **One pin pulled (single FC fires)**: Door swings open on the remaining hinge pin (which acts as the pivot). Springs push parachute out through the opening. The door stays attached via the remaining hinge — no tether needed for the door itself
+- **Both pins pulled (both FCs fire)**: Door detaches completely (tethered separately). Full opening
+
+**Advantages:**
+
+- Degraded mode is mechanically obvious and guaranteed — a door with one hinge removed *must* swing open under spring load. No careful "one half can't hold" engineering needed
+- The remaining hinge pin acts as both pivot and tether — door cannot become a separate falling object in the single-FC case
+- Simpler redundancy argument for TAP review: "pull either pin, door opens" is easy to demonstrate and explain
+- Springs push parachute out sideways through the hatch opening — spring force acts directly on parachute, not requiring full axial body separation
+- Servo and battery enclosures can be positioned near hinge pins, integrated into the door frame
+
+**Concerns:**
+
+- Body tube structural integrity — the door cutout weakens the tube. Need reinforcement around the hatch opening (thicker frame, doubler plate, or integrated printed frame)
+- Aerodynamic discontinuity — door edges and frame create surface irregularities. At subsonic speeds this may be acceptable but needs analysis
+- Door size — must be large enough for parachute to exit cleanly when pushed by springs. Parachute packing must account for sideways deployment
+- Hinge pin loads — pins carry flight loads in shear. Pin diameter and material must be sized for worst-case axial + bending loads
+- Spring arrangement — springs push parachute toward the door opening. Spring orientation and mount points differ from axial separation designs
+- Swing clearance — door must swing open without hitting launch rail, other body sections, or fin can
+- Two-pin-pulled case — door detaches, needs tether. Tether must not tangle with parachute
+
+#### Common Design Elements
+
+Both options share:
+
+| Element | Description |
+|---------|-------------|
+| **Identical halves** | Same part printed twice per joint (bayonet halves or door+frame assemblies). One design, multiple prints |
+| **Spring deployment** | Preloaded springs push parachute out after release |
+| **Wall-hugging servo enclosures** | Servo + battery in smooth 3D printed fairings against tube wall (see section 2.9) |
+| **4 servos total** | One per mechanism half, 2 per joint, 2 joints |
+| **Tethering** | All released parts remain attached to a rocket section |
+| **FC mapping** | FC #1 controls half A at both joints, FC #2 controls half B at both joints |
+
+### 4.4 Redundancy Analysis
+
+Applies to both mechanism options:
 
 | Scenario | Result |
 |----------|--------|
-| Both FCs fire normally | Both halves release simultaneously → clean separation |
-| FC #1 fires, FC #2 fails | Half A releases → half B alone cannot hold → separation |
-| FC #2 fires, FC #1 fails | Half B releases → half A alone cannot hold → separation |
+| Both FCs fire normally | Both halves release → clean separation/opening |
+| FC #1 fires, FC #2 fails | Half A releases → separation (bayonet: one half can't hold; door: swings open on remaining hinge) |
+| FC #2 fires, FC #1 fails | Half B releases → separation (same logic) |
 | Both FCs fail | Both halves remain locked → no separation (ballistic) |
-| Servo #1 jams (mechanical) | FC #2 releases half B → half A alone cannot hold → separation |
-| Servo #2 jams (mechanical) | FC #1 releases half A → half B alone cannot hold → separation |
+| Servo #1 jams (mechanical) | FC #2 releases half B → separation |
+| Servo #2 jams (mechanical) | FC #1 releases half A → separation |
 
-True independent redundancy: no single electrical or mechanical failure prevents separation.
+True independent redundancy in both options: no single electrical or mechanical failure prevents recovery.
 
-#### Manufacturing Advantage
+### 4.5 Mechanism Selection — TODO
 
-One OpenSCAD design, one STL/3MF, print multiples. All four bayonet halves (2 per joint) are the same part. Spares are trivial — bring extras to the launch.
+Decision criteria for selecting between Option A (bayonet) and Option B (hinged door):
 
-#### Design Challenges — TODO
+1. **Prototype both** — print test versions of each, test fit and release on a body tube section
+2. **Structural analysis** — which is more robust under flight loads?
+3. **Reliability of degraded mode** — door swing-open is inherently more reliable than "one bayonet half can't hold." This favors Option B
+4. **Airframe impact** — bayonet requires no tube cutout; door weakens the tube. This favors Option A
+5. **Parachute deployment path** — axial (bayonet) vs. sideways through hatch (door). Which is more reliable?
+6. **TAP feedback** — discuss both with Rolf before committing
+7. **Ease of field assembly** — which is simpler to set up and verify at the launch site?
 
-- **Lug geometry**: Each half carries ~50% of flight loads when locked. Lug shape must be strong enough for this but unable to resist spring force alone. This is the critical design parameter — lug engagement depth and spring force must be carefully matched
-- **Rotational vs. linear release**: Decide whether the servo rotates the half (traditional bayonet twist) or pulls it linearly (slide out). Rotation may be simpler for a 3D printed part; linear pull may be more reliable with a servo arm
-- **Anti-vibration**: Each half must not creep toward release under motor vibration. Options: detent, friction fit, slight interference, servo holding torque
-- **Spring sizing**: Springs must overcome friction of one remaining half plus parachute packing resistance. Must separate reliably at all altitudes. Ground test required
-- **Servo torque/force**: Must overcome detent + friction to release the half. Must not back-drive under vibration. Servo selection and torque analysis needed
-- **Tolerances**: 3D printed parts — test fit, iterate. Print several and measure variation
-- **Cold weather**: Verify mechanism operation at expected Swedish winter temperatures (-10 to -20°C at altitude). PC CF should be fine, but servo grease and spring rate may change
-- **Discuss with Rolf**: Get TAP approval of non-pyro separation concept before detailed design
+### 4.6 Design Challenges — TODO
 
-#### Considered Alternatives
+Regardless of which mechanism is selected:
 
-The following approaches were evaluated before selecting the symmetric dual-half bayonet:
-
-- **Dual pin**: Two independent pins, each pulled by one servo. Simpler mechanically, but harder to ensure one pin alone cannot hold against springs while both together resist flight loads. Pin geometry is fussy.
-- **Single bayonet with dual servos**: One bayonet ring, two servos rotating it in opposite directions. Cleaner single mechanism, but a jammed bayonet blocks both systems — not truly independent failure paths.
-- **Hybrid (bayonet + pin bypass)**: Primary via bayonet rotation, backup via pin pull releasing entire bayonet assembly. True mechanical independence, but more complex, more parts, tether management concerns.
-
-The symmetric dual-half bayonet was selected because it combines true independent redundancy with manufacturing simplicity — one part printed multiple times.
-
-### 4.4 Design Challenges — TODO
-
-General challenges regardless of mechanism specifics:
-
-- **Structural analysis**: Combined halves must handle boost loads (axial: motor thrust + drag, bending: wind loads, vibration: motor resonance)
-- **Spring force**: Must reliably push sections apart and deploy parachute at all expected altitudes. Validated by ground testing
-- **Servo selection**: Must reliably actuate in cold weather (Swedish winter), under vibration, after sustaining boost G-loads. Torque margin needed
-- **Tolerances**: 3D printed mechanism parts have different tolerances than machined parts. Test under realistic conditions, print spares
-- **Tethering**: All released mechanism parts (bayonet halves, servos) must remain attached to a rocket section via tether. No parts may descend without a recovery system (Tripoli non-certification condition)
+- **Structural analysis**: Mechanism must handle boost loads (axial: motor thrust + drag, bending: wind loads, vibration: motor resonance)
+- **Spring force**: Must reliably push parachute out at all expected altitudes. Validated by ground testing
+- **Servo selection**: Must reliably actuate in cold weather (Swedish winter, -10 to -20°C at altitude), under vibration, after sustaining boost G-loads. Torque margin needed
+- **Tolerances**: 3D printed parts have different tolerances than machined parts. Test under realistic conditions, print spares
+- **Tethering**: All released parts must remain attached to a rocket section. No parts may descend without a recovery system (Tripoli non-certification condition)
+- **Wall-hugging enclosures**: Must not snag parachute or shock cord. Ground test with actual parachute packing
 - **Discuss with Rolf early**: Non-pyro separation is less common for L3. TAP approval of the concept is needed before detailed design
 
-### 4.5 Drogue Deployment
+### 4.7 Drogue Deployment
 
 | Parameter | Value |
 |-----------|-------|
 | Trigger | Apogee detection (barometric) |
-| Mechanism | Dual-half bayonet release + spring separation |
+| Mechanism | Servo-actuated release + spring deployment (TBD: bayonet or hinged door) |
 | Parachute | TBD size drogue |
 | Descent rate under drogue | TBD m/s |
 | Separation point | TBD |
 
-### 4.6 Main Deployment
+### 4.8 Main Deployment
 
 | Parameter | Value |
 |-----------|-------|
 | Trigger | Altitude-based (TBD meters AGL) |
-| Mechanism | Dual-half bayonet release + spring separation |
+| Mechanism | Servo-actuated release + spring deployment (TBD: bayonet or hinged door) |
 | Parachute | TBD size main |
 | Descent rate under main | TBD m/s (must not exceed 35 ft/s = 10.7 m/s per Tripoli rules) |
 | Separation point | TBD |
 
-### 4.7 Landing Velocity
+### 4.9 Landing Velocity
 
 | Parameter | Value |
 |-----------|-------|
@@ -363,25 +433,33 @@ General challenges regardless of mechanism specifics:
 | Liftoff weight | TBD |
 | Main parachute Cd | TBD |
 
-### 4.8 Redundancy Architecture
+### 4.10 Redundancy Architecture
 
 Per Tripoli L3 rules: *"Dual redundant electronics are required for all recovery events. Two completely independent and separate electronic recovery systems must be incorporated. Neither system must adversely affect the other. Redundancy means completely separate systems, including batteries, switches, avionics, and energetics."*
 
-With the dual-half bayonet, "energetics" is replaced by servo + bayonet half + spring. Each system controls its own bayonet halves across both separation joints.
+With servo-actuated separation, "energetics" is replaced by servo + mechanism half + spring. Each system controls its own mechanism halves across both separation joints.
 
 | Component | Primary System (FC #1) | Backup System (FC #2) |
 |-----------|----------------------|---------------------|
 | Flight computer | Custom FC (CATS Vega clone, improved) | CATS Vega (original) or second custom clone |
 | Battery | Dedicated battery #1 | Dedicated battery #2 |
 | Arming switch | Key switch #1 | Key switch #2 |
-| Drogue release | Servo #1 → bayonet half A (drogue joint) | Servo #2 → bayonet half B (drogue joint) |
-| Main release | Servo #3 → bayonet half A (main joint) | Servo #4 → bayonet half B (main joint) |
+| Drogue release | Servo #1 → mechanism half A (drogue joint) | Servo #2 → mechanism half B (drogue joint) |
+| Main release | Servo #3 → mechanism half A (main joint) | Servo #4 → mechanism half B (main joint) |
 
-The two systems share no electrical connections. Each has independent power, switching, sensing, and servo output. Each controls one of the two identical bayonet halves at each joint. Either system alone triggers separation.
+The two systems share no electrical connections. Each has independent power, switching, sensing, and servo output. Each controls one of the two identical mechanism halves at each joint. Either system alone triggers deployment.
 
-### 4.9 Motor Note
+### 4.11 Motor Note
 
 The M1350W-PS is a plugged motor — no motor ejection charge. All recovery depends entirely on the dual redundant electronic systems. There is no motor backup.
+
+### 4.12 Considered and Rejected Alternatives
+
+The following approaches were evaluated earlier and set aside:
+
+- **Dual pin**: Two independent pins, each pulled by one servo. Simpler mechanically, but harder to ensure one pin alone cannot hold against springs while both together resist flight loads. Pin geometry is fussy
+- **Single bayonet with dual servos**: One bayonet ring, two servos rotating it in opposite directions. Cleaner single mechanism, but a jammed bayonet blocks both systems — not truly independent failure paths
+- **Hybrid (bayonet + pin bypass)**: Primary via bayonet rotation, backup via pin pull releasing entire bayonet assembly. True mechanical independence, but asymmetric design — two different part types, more complex, tether management concerns
 
 ---
 
@@ -399,7 +477,7 @@ The M1350W-PS is a plugged motor — no motor ejection charge. All recovery depe
 - Battery #2 → Key switch #2 → Backup FC → Servo #2 (drogue half B) + Servo #4 (main half B)
 - Physical separation between systems
 - Servo connections (signal + power)
-- Mechanical linkage to bayonet halves (conceptual)
+- Mechanical linkage to mechanism halves (conceptual)
 
 ### 5.2 Primary System
 
@@ -407,8 +485,8 @@ The M1350W-PS is a plugged motor — no motor ejection charge. All recovery depe
 |-----------|------|-----|
 | Power | Battery #1 (TBD V) | Key switch #1 |
 | Switched power | Key switch #1 | Primary FC power input |
-| Servo channel 1 | Primary FC drogue output | Servo #1 → drogue joint bayonet half A |
-| Servo channel 2 | Primary FC main output | Servo #3 → main joint bayonet half A |
+| Servo channel 1 | Primary FC drogue output | Servo #1 → drogue joint mechanism half A |
+| Servo channel 2 | Primary FC main output | Servo #3 → main joint mechanism half A |
 
 ### 5.3 Backup System
 
@@ -416,8 +494,8 @@ The M1350W-PS is a plugged motor — no motor ejection charge. All recovery depe
 |-----------|------|-----|
 | Power | Battery #2 (TBD V) | Key switch #2 |
 | Switched power | Key switch #2 | Backup FC power input |
-| Servo channel 1 | Backup FC drogue output | Servo #2 → drogue joint bayonet half B |
-| Servo channel 2 | Backup FC main output | Servo #4 → main joint bayonet half B |
+| Servo channel 1 | Backup FC drogue output | Servo #2 → drogue joint mechanism half B |
+| Servo channel 2 | Backup FC main output | Servo #4 → main joint mechanism half B |
 
 ---
 
@@ -606,14 +684,16 @@ If flutter margin insufficient with PC CF alone:
 - [ ] Motor mount assembly
 - [ ] Centering ring installation
 - [ ] Body tube preparation
-- [ ] Bayonet half printing and fit testing
-- [ ] Separation mechanism assembly and bench testing
+- [ ] Separation mechanism prototype printing and testing (both options)
+- [ ] Mechanism selection (bayonet vs. hinged door) after prototyping
+- [ ] Final mechanism parts printing and fit testing
+- [ ] Wall-hugging servo enclosure printing and fit testing
 - [ ] Electronics bay / nose cone electronics construction
 - [ ] Dual flight computer installation and wiring
 - [ ] Servo installation and testing
 - [ ] Recovery harness assembly
-- [ ] Parachute packing
-- [ ] Spring preload and bayonet engagement testing
+- [ ] Parachute packing and deployment test through mechanism
+- [ ] Spring preload and mechanism engagement testing
 - [ ] Final assembly
 - [ ] Weight and CG measurements
 - [ ] CP marking on airframe
@@ -655,7 +735,7 @@ Electronic deployment count: 1 of 2 minimum complete.
 - [ ] Igniter (FirstFire)
 - [ ] Batteries charged (2×, one per system)
 - [ ] Key switches and keys (2×)
-- [ ] Spare bayonet halves and servos
+- [ ] Spare mechanism halves and servos
 - [ ] Tools for field assembly
 
 ### 12.2 At Launch Site — Before Assembly
@@ -674,11 +754,11 @@ Electronic deployment count: 1 of 2 minimum complete.
 - [ ] Pack drogue parachute
 - [ ] Pack main parachute
 - [ ] Preload separation springs
-- [ ] Engage both bayonet halves at drogue joint
-- [ ] Engage both bayonet halves at main joint
-- [ ] Verify bayonet engagement at both joints
+- [ ] Engage both mechanism halves at drogue joint
+- [ ] Engage both mechanism halves at main joint
+- [ ] Verify mechanism engagement at both joints
 - [ ] Verify all tethers attached
-- [ ] Connect servo mechanisms to bayonet halves
+- [ ] Connect servo mechanisms
 - [ ] Connect primary FC wiring and servos (#1, #3)
 - [ ] Connect backup FC wiring and servos (#2, #4)
 - [ ] Arm primary system (key switch #1)
@@ -707,15 +787,17 @@ Electronic deployment count: 1 of 2 minimum complete.
 |-------------|------------|-------------|
 | Motor CATO | Single-use motor, proper assembly | Non-certification |
 | Motor retention failure | Adequate retention hardware, inspection | Non-certification |
-| Primary electronics failure | Backup system releases half B → separation | Successful recovery |
-| Backup electronics failure | Primary system releases half A → separation | Successful recovery |
+| Primary electronics failure | Backup system releases half B → deployment | Successful recovery |
+| Backup electronics failure | Primary system releases half A → deployment | Successful recovery |
 | Both electronics fail | Design for reliability, ground test | Non-certification (ballistic descent) |
-| Single servo failure | Other system's servo releases its half → one half cannot hold alone → separation | Successful recovery |
-| Both servos fail on same joint | Ground testing, servo selection, cold testing | Failed separation |
-| Bayonet half jammed | Tolerances, lubrication, vibration testing, print spares, test fit | Failed separation (mitigated: other half release still causes separation) |
-| Spring insufficient | Ground testing at various temperatures, margin in spring force | Incomplete separation |
-| Premature bayonet release (vibration/G) | Detent design, lug geometry, servo holding torque, vibration testing | Drag separation during boost |
+| Single servo failure | Other system's servo releases its half → deployment | Successful recovery |
+| Both servos fail on same joint | Ground testing, servo selection, cold testing | Failed deployment |
+| Mechanism half jammed | Tolerances, lubrication, testing, print spares; other half release still triggers deployment | Successful recovery (degraded) |
+| Spring insufficient | Ground testing at various temperatures, margin in spring force | Incomplete deployment |
+| Premature release (vibration/G) | Structural analysis, detent/pin design, vibration testing | Premature deployment during boost |
 | Tether tangle with parachute | Tether routing, length management, ground test | Tangled recovery |
+| Body tube weakened by door cutout (Option B) | Reinforced frame, doubler plate, structural analysis | Structural failure |
+| Parachute snags on servo enclosure | Wall-hugging smooth fairing, ground test with actual packing | Failed deployment |
 | Fin flutter | Flutter analysis, carbon reinforcement, progressive test flights | Structural failure |
 | Unstable flight | Stability analysis, CP/CG verification, OpenRocket sim | Unsafe flight |
 | Parachute tangle | Proper packing, ground test | Failed recovery |
@@ -724,12 +806,15 @@ Electronic deployment count: 1 of 2 minimum complete.
 
 | Test | Purpose | When |
 |------|---------|------|
-| Bayonet half fit test | Verify printed parts engage/release cleanly | After printing |
-| Separation bench test (both halves) | Verify spring separates when both released | During construction |
-| Redundancy test (half A only) | Verify releasing half A alone causes separation | During construction |
-| Redundancy test (half B only) | Verify releasing half B alone causes separation | During construction |
+| Mechanism prototype (Option A) | Print and test bayonet half engagement/release | Early prototyping |
+| Mechanism prototype (Option B) | Print and test hinged door engagement/release/swing | Early prototyping |
+| Mechanism selection | Compare prototypes, select winner | After prototyping |
+| Servo enclosure fit test | Verify parachute slides past without snagging | During construction |
+| Separation bench test (both halves) | Verify spring deploys parachute when both released | During construction |
+| Redundancy test (half A only) | Verify releasing half A alone causes deployment | During construction |
+| Redundancy test (half B only) | Verify releasing half B alone causes deployment | During construction |
 | Cold temperature test | Verify servo and mechanism operation at -10 to -20°C | During construction |
-| Vibration/shake test | Verify bayonet halves don't disengage under simulated flight loads | During construction |
+| Vibration/shake test | Verify mechanism doesn't release under simulated flight loads | During construction |
 | Tether deployment test | Verify tethered parts don't tangle with parachute | During construction |
 | Flight #2 (J420R) | Validate airframe, electronics, separation mechanism in flight | Before L flight |
 | Flight #3 (L1000W) | Stress test at higher loads and speeds | Before M flight |
@@ -743,7 +828,7 @@ Electronic deployment count: 1 of 2 minimum complete.
 | FAR 101.25 | Altitude prediction within waiver |
 | Waiver radius | Wind simulation, dual deploy for tight landing |
 | Landing velocity ≤ 35 ft/s | Parachute sizing calculation |
-| Dual redundant electronics | Two independent systems, each controlling one bayonet half |
+| Dual redundant electronics | Two independent systems, each controlling one mechanism half |
 | No untethered components | All mechanism parts tethered to rocket sections |
 | CP marked on rocket | External marking |
 
@@ -757,7 +842,7 @@ Electronic deployment count: 1 of 2 minimum complete.
 
 ### B. OpenSCAD Design Files
 
-*TODO: Include .scad source for fin can, fins, and bayonet half*
+*TODO: Include .scad source for fin can, fins, mechanism halves, and servo enclosures*
 
 ### C. Thrust Curve Data
 
@@ -773,18 +858,20 @@ Electronic deployment count: 1 of 2 minimum complete.
 
 ### F. Separation Mechanism Design
 
-*TODO: Detailed drawings of dual-half bayonet mechanism, including:*
+*TODO: Detailed drawings of selected separation mechanism, including:*
 
-- Bayonet half geometry (OpenSCAD parametric design)
-- Lug engagement depth and load analysis
-- Spring selection and force calculations (must overcome single-half friction)
+- Mechanism half geometry (OpenSCAD parametric design)
+- Load analysis (engagement depth / hinge pin shear)
+- Spring selection and force calculations
 - Servo selection and torque requirements
-- Anti-vibration detent design
+- Anti-vibration design (detent / pin retention)
+- Wall-hugging servo enclosure design
 - Redundancy verification test results (each half independently)
 - Tether routing plan
 - Assembly and preload procedure
 - Print settings and tolerance measurements
 - Cold weather test results
+- Prototype comparison results (bayonet vs. hinged door)
 
 ### G. Forms
 

--- a/docs/certification/l3-design-document.md
+++ b/docs/certification/l3-design-document.md
@@ -44,7 +44,7 @@ Tripoli Level 3 high-power certification using a scratch-built rocket with a sin
 | Dry weight (no motor) | TBD |
 | Liftoff weight (with motor) | TBD |
 | Motor | AeroTech M1350W-PS (75mm, 5178 N-s) |
-| Recovery | Dual deploy, dual redundant electronics |
+| Recovery | Dual deploy, dual redundant electronics, servo-actuated spring release |
 | Expected altitude | TBD |
 | Number of fins | TBD |
 | Fin material | Spectrum PC CF (3D printed polycarbonate + carbon fiber) |
@@ -55,6 +55,7 @@ Tripoli Level 3 high-power certification using a scratch-built rocket with a sin
 - Progressive flight testing on J and L motors before cert flight
 - 3D printed fin can in PC CF with carbon rod reinforcement for flutter resistance
 - Dual redundant electronics as required by Tripoli L3 rules
+- Servo-actuated spring release instead of black powder ejection charges
 - Single-use motor to avoid reloadable hardware risk
 
 ---
@@ -75,12 +76,13 @@ Tripoli Level 3 high-power certification using a scratch-built rocket with a sin
 - Electronics bay location
 - Recovery section layout
 - Motor mount position and length
+- Separation mechanism locations
 
 ### 2.2 Body Tube
 
 | Parameter | Value |
 |-----------|-------|
-| Material | TBD |
+| Material | TBD (commercial prebuilt tube) |
 | Outer diameter | TBD |
 | Inner diameter | TBD |
 | Wall thickness | TBD |
@@ -94,6 +96,8 @@ Tripoli Level 3 high-power certification using a scratch-built rocket with a sin
 | Material | TBD (3D printed or commercial) |
 | Length | TBD |
 | Shoulder length | TBD |
+
+Electronics may be housed in the nose cone — see section 2.8.
 
 ### 2.4 Fin Can Assembly
 
@@ -146,11 +150,16 @@ For pre-certification test flights:
 
 | Parameter | Value |
 |-----------|-------|
-| Location | TBD (typically mid-body between recovery sections) |
+| Location | TBD — either mid-body or nose cone |
 | Length | TBD |
 | Sled material | TBD |
 | Switch access | External key switches (2×, one per system) |
-| Charge wells | 4× (2 drogue + 2 main, one per system) |
+
+**Nose cone option**: Placing electronics in the nose cone simplifies wiring (all forward), and the electronics mass helps CG stay forward for stability. Trade-off is accessibility and nose cone structural requirements.
+
+**Mid-body option**: Traditional e-bay between recovery sections. Easier access, standard approach.
+
+*TODO: Decide based on airframe layout and CG analysis.*
 
 ### 2.9 Rail Guides
 
@@ -170,7 +179,7 @@ For pre-certification test flights:
 
 | Item | Specification | Quantity | Source |
 |------|--------------|----------|--------|
-| Body tube | TBD | TBD | TBD |
+| Body tube | TBD (commercial prebuilt) | TBD | TBD |
 | Nose cone | TBD | 1 | TBD |
 | Fin can body (printed) | Spectrum PC CF | 1 set | Printed by candidate |
 | Fins (printed) | Spectrum PC CF | TBD | Printed by candidate |
@@ -178,7 +187,7 @@ For pre-certification test flights:
 | Centering rings | TBD | TBD | TBD |
 | Motor mount tube | 75mm ID | 1 | TBD |
 | Motor retainer | TBD | 1 | TBD |
-| E-bay sled | TBD | 1 | TBD |
+| E-bay structure | TBD | 1 | TBD |
 | Bulkheads | TBD | 2 | TBD |
 | Rail guides | TBD | TBD | TBD |
 | Shock cord | TBD | TBD | TBD |
@@ -191,20 +200,22 @@ For pre-certification test flights:
 | Drogue parachute | TBD size | 1 | TBD |
 | Main parachute | TBD size | 1 | TBD |
 | Nomex chute protectors | TBD | 2 | TBD |
-| Shear pins | TBD | TBD | TBD |
-| Ejection charges (BP) | TBD grams each | 4 (2 per system) | TBD |
+| Separation springs | TBD | TBD | TBD |
+| Retention pins | TBD | TBD | TBD |
+| Servos (separation) | TBD | TBD | TBD |
 
 ### 3.3 Electronics
 
 | Item | Specification | Quantity | Source |
 |------|--------------|----------|--------|
-| Primary flight computer | Custom (CATS Vega-based) | 1 | Built by candidate |
-| Backup flight computer | TBD | 1 | TBD |
+| Primary flight computer | Custom (CATS Vega clone, improved) | 1 | Built by candidate |
+| Backup flight computer | CATS Vega (original) or second custom clone | 1 | TBD |
 | Battery (primary) | TBD | 1 | TBD |
 | Battery (backup) | TBD | 1 | TBD |
 | Key switch (primary) | TBD | 1 | TBD |
 | Key switch (backup) | TBD | 1 | TBD |
-| E-matches / igniters | TBD | 4 | TBD |
+| Servos (drogue separation) | TBD | TBD per system | TBD |
+| Servos (main separation) | TBD | TBD per system | TBD |
 
 ### 3.4 Motor
 
@@ -220,34 +231,66 @@ For pre-certification test flights:
 
 ### 4.1 Recovery Architecture
 
-Dual deployment with dual redundant electronics:
+Dual deployment using servo-actuated spring release mechanisms, controlled by dual redundant electronics:
 
 | Event | Altitude | Device | Action |
 |-------|----------|--------|--------|
-| Apogee | Apogee detection | Primary FC + Backup FC | Drogue parachute deployment |
-| Main | TBD (e.g., 300m AGL) | Primary FC + Backup FC | Main parachute deployment |
+| Apogee | Apogee detection | Primary FC + Backup FC | Servo releases pin → spring separates body → drogue deploys |
+| Main | TBD (e.g., 300m AGL) | Primary FC + Backup FC | Servo releases pin → spring separates body → main deploys |
 
-### 4.2 Drogue Deployment
+### 4.2 Separation Mechanism Concept
+
+Instead of black powder ejection charges, separation is achieved mechanically:
+
+1. **Springs** are preloaded between body sections during assembly, providing separation force
+2. **Retention pins** hold the sections together against the spring preload during flight
+3. **Servos** pull the pins out on command from the flight computer
+4. Once pins are removed, springs push the sections apart and deploy the parachute
+
+**Advantages over BP charges**:
+
+- No pyrotechnics — simpler handling, no e-matches, no charge sizing
+- Repeatable and testable — same force every time
+- No hot gas near parachutes — no Nomex protectors needed
+- Clean separation — no soot, no pressure spike
+
+**Design challenges — TODO**:
+
+- **Redundancy logic problem**: Tripoli requires each system to independently trigger recovery. This means each FC must be able to independently release the pins. But if two independent servos can each release, the pin retention is only as strong as the weaker servo holding mechanism. Need a design where:
+  - Either servo can independently release the pin (true redundancy)
+  - But the pin cannot accidentally release under flight loads (vibration, G-forces)
+  - And one servo failure does not jam the other servo's ability to release
+- **Possible approaches (all need analysis)**:
+  - Two pins per joint, each controlled by one servo — either pin removal destabilizes enough for separation, but both pins together handle flight loads
+  - Single pin with two independent pull mechanisms (e.g., two cables to same pin, either can pull it)
+  - Rotary latch with two independent release paths
+  - Other mechanisms TBD
+- **Pin structural requirements**: Pins must withstand aerodynamic loads, motor thrust loads, and vibration during boost without premature release. Shear strength analysis needed.
+- **Spring force**: Must be sufficient to overcome friction and reliably push sections apart and deploy parachute at all expected altitudes (varying air density). Must be validated by ground testing.
+- **Servo reliability**: Servo must reliably actuate in cold weather (Swedish winter conditions), under vibration, and after sustaining boost G-loads. Servo selection and testing critical.
+- **Discuss with Rolf early**: Non-pyro separation is less common for L3. TAP approval of the concept is needed before detailed design.
+
+### 4.3 Drogue Deployment
 
 | Parameter | Value |
 |-----------|-------|
 | Trigger | Apogee detection (barometric) |
+| Mechanism | Servo-actuated pin release + spring separation |
 | Parachute | TBD size drogue |
 | Descent rate under drogue | TBD m/s |
 | Separation point | TBD |
-| Charge size | TBD grams BP (×2, one per system) |
 
-### 4.3 Main Deployment
+### 4.4 Main Deployment
 
 | Parameter | Value |
 |-----------|-------|
 | Trigger | Altitude-based (TBD meters AGL) |
+| Mechanism | Servo-actuated pin release + spring separation |
 | Parachute | TBD size main |
 | Descent rate under main | TBD m/s (must not exceed 35 ft/s = 10.7 m/s per Tripoli rules) |
 | Separation point | TBD |
-| Charge size | TBD grams BP (×2, one per system) |
 
-### 4.4 Landing Velocity
+### 4.5 Landing Velocity
 
 | Parameter | Value |
 |-----------|-------|
@@ -256,21 +299,25 @@ Dual deployment with dual redundant electronics:
 | Liftoff weight | TBD |
 | Main parachute Cd | TBD |
 
-### 4.5 Redundancy Architecture
+### 4.6 Redundancy Architecture
 
 Per Tripoli L3 rules: *"Dual redundant electronics are required for all recovery events. Two completely independent and separate electronic recovery systems must be incorporated. Neither system must adversely affect the other. Redundancy means completely separate systems, including batteries, switches, avionics, and energetics."*
 
+Note: "energetics" in the Tripoli rules refers to ejection charges. With servo-actuated separation, the equivalent is the servo + pin + spring mechanism. Each system must independently be capable of triggering separation.
+
 | Component | Primary System | Backup System |
 |-----------|---------------|---------------|
-| Flight computer | Custom FC #1 | TBD (Custom FC #2 or commercial) |
+| Flight computer | Custom FC (CATS Vega clone, improved) | CATS Vega (original) or second custom clone |
 | Battery | Dedicated battery #1 | Dedicated battery #2 |
 | Arming switch | Key switch #1 | Key switch #2 |
-| Drogue charge | Charge #1 | Charge #2 |
-| Main charge | Charge #3 | Charge #4 |
+| Drogue release | Servo #1 → pin/mechanism | Servo #2 → pin/mechanism |
+| Main release | Servo #3 → pin/mechanism | Servo #4 → pin/mechanism |
 
-The two systems share no electrical connections. Each has independent power, switching, sensing, and pyro output.
+The two systems share no electrical connections. Each has independent power, switching, sensing, and servo output.
 
-### 4.6 Motor Note
+*TODO: Design the mechanical interface so that either servo can independently cause separation without the other. See section 4.2 design challenges.*
+
+### 4.7 Motor Note
 
 The M1350W-PS is a plugged motor — no motor ejection charge. All recovery depends entirely on the dual redundant electronic systems. There is no motor backup.
 
@@ -280,17 +327,17 @@ The M1350W-PS is a plugged motor — no motor ejection charge. All recovery depe
 
 *Per Tripoli L3 requirement 1.a.iii: "A wiring diagram that accurately reflects the wiring provided by the candidate from the power source, switches, and ejection charges."*
 
-*Note: Schematics of the actual flight computer internals are NOT required — only the wiring from power source, through switches, to the flight computers and ejection charges.*
+*Note: With servo-actuated separation, the wiring diagram shows servo connections instead of e-match/charge connections. Schematics of the actual flight computer internals are NOT required — only the wiring from power source, through switches, to the flight computers and servos.*
 
 ### 5.1 Wiring Diagram
 
 *TODO: Create wiring diagram showing:*
 
-- Battery #1 → Key switch #1 → Primary FC → Drogue charge #1 + Main charge #1
-- Battery #2 → Key switch #2 → Backup FC → Drogue charge #2 + Main charge #2
+- Battery #1 → Key switch #1 → Primary FC → Drogue servo #1 + Main servo #1
+- Battery #2 → Key switch #2 → Backup FC → Drogue servo #2 + Main servo #2
 - Physical separation between systems
-- E-match connections
-- Charge well layout
+- Servo connections (signal + power)
+- Mechanical linkage to pins (conceptual)
 
 ### 5.2 Primary System
 
@@ -298,8 +345,8 @@ The M1350W-PS is a plugged motor — no motor ejection charge. All recovery depe
 |-----------|------|-----|
 | Power | Battery #1 (TBD V) | Key switch #1 |
 | Switched power | Key switch #1 | Primary FC power input |
-| Pyro channel 1 | Primary FC drogue output | E-match → drogue charge #1 |
-| Pyro channel 2 | Primary FC main output | E-match → main charge #1 |
+| Servo channel 1 | Primary FC drogue output | Servo #1 → drogue pin release |
+| Servo channel 2 | Primary FC main output | Servo #3 → main pin release |
 
 ### 5.3 Backup System
 
@@ -307,8 +354,8 @@ The M1350W-PS is a plugged motor — no motor ejection charge. All recovery depe
 |-----------|------|-----|
 | Power | Battery #2 (TBD V) | Key switch #2 |
 | Switched power | Key switch #2 | Backup FC power input |
-| Pyro channel 1 | Backup FC drogue output | E-match → drogue charge #2 |
-| Pyro channel 2 | Backup FC main output | E-match → main charge #2 |
+| Servo channel 1 | Backup FC drogue output | Servo #2 → drogue pin release |
+| Servo channel 2 | Backup FC main output | Servo #4 → main pin release |
 
 ---
 
@@ -336,7 +383,7 @@ The M1350W-PS is a plugged motor — no motor ejection charge. All recovery depe
 | Parameter | Value |
 |-----------|-------|
 | Method | TBD |
-| Rating | Must retain motor under full thrust + ejection loads |
+| Rating | Must retain motor under full thrust loads |
 
 ### 6.3 Thrust-to-Weight Ratio
 
@@ -497,16 +544,18 @@ If flutter margin insufficient with PC CF alone:
 - [ ] Motor mount assembly
 - [ ] Centering ring installation
 - [ ] Body tube preparation
-- [ ] Electronics bay construction
-- [ ] E-bay sled with dual flight computers
-- [ ] Wiring of dual redundant systems
+- [ ] Separation mechanism fabrication and testing
+- [ ] Electronics bay / nose cone electronics construction
+- [ ] Dual flight computer installation and wiring
+- [ ] Servo mechanism installation and testing
 - [ ] Recovery harness assembly
 - [ ] Parachute packing
+- [ ] Spring preload and pin retention testing
 - [ ] Final assembly
 - [ ] Weight and CG measurements
 - [ ] CP marking on airframe
-- [ ] Ground test of electronics
-- [ ] Ejection charge ground testing
+- [ ] Ground test of electronics (both systems independently)
+- [ ] Separation mechanism ground testing (both systems independently)
 
 ### 10.2 Construction Photos
 
@@ -541,12 +590,10 @@ Electronic deployment count: 1 of 2 minimum complete.
 - [ ] Rocket fully assembled and inspected
 - [ ] Motor (M1350W-PS)
 - [ ] Igniter (FirstFire)
-- [ ] Ejection charges prepared (4×: 2 drogue + 2 main)
-- [ ] E-matches (4×)
 - [ ] Batteries charged (2×, one per system)
 - [ ] Key switches and keys (2×)
+- [ ] Spare servos
 - [ ] Tools for field assembly
-- [ ] Recovery wadding / Nomex protectors
 
 ### 12.2 At Launch Site — Before Assembly
 
@@ -563,10 +610,12 @@ Electronic deployment count: 1 of 2 minimum complete.
 - [ ] Install motor in rocket with retention
 - [ ] Pack drogue parachute
 - [ ] Pack main parachute
-- [ ] Install ejection charges (4×)
-- [ ] Install e-matches in charges
-- [ ] Connect primary FC wiring
-- [ ] Connect backup FC wiring
+- [ ] Preload separation springs
+- [ ] Install retention pins
+- [ ] Verify pin engagement
+- [ ] Connect servo mechanisms
+- [ ] Connect primary FC wiring and servos
+- [ ] Connect backup FC wiring and servos
 - [ ] Arm primary system (key switch #1)
 - [ ] Verify primary FC status (LED/beep)
 - [ ] Arm backup system (key switch #2)
@@ -593,23 +642,28 @@ Electronic deployment count: 1 of 2 minimum complete.
 |-------------|------------|-------------|
 | Motor CATO | Single-use motor, proper assembly | Non-certification |
 | Motor retention failure | Adequate retention hardware, inspection | Non-certification |
-| Primary electronics failure | Backup system fires charges | Successful recovery |
-| Backup electronics failure | Primary system fires charges | Successful recovery |
+| Primary electronics failure | Backup system actuates servos | Successful recovery |
+| Backup electronics failure | Primary system actuates servos | Successful recovery |
 | Both electronics fail | Design for reliability, ground test | Non-certification (ballistic descent) |
+| Servo failure (single) | Redundant servo on other system releases same joint | Successful recovery |
+| Servo failure (both on same joint) | Ground testing, servo selection, cold testing | Failed separation |
+| Pin jammed | Design for clean release, lubrication, vibration testing | Failed separation |
+| Spring insufficient | Ground testing at various temperatures, margin in spring force | Incomplete separation |
+| Premature pin release (vibration/G) | Pin shear strength analysis, locking mechanism | Drag separation during boost |
 | Fin flutter | Flutter analysis, carbon reinforcement, progressive test flights | Structural failure |
 | Unstable flight | Stability analysis, CP/CG verification, OpenRocket sim | Unsafe flight |
-| Parachute tangle | Proper packing, Nomex protectors, ground test | Failed recovery |
-| Shear pin failure (premature separation) | Correct shear pin sizing, ground test | Drag separation |
-| Ejection charge insufficient | Ground test charges, calculate volume | Failed deployment |
-| Ejection charge excessive | Ground test charges, calculate volume | Structural damage |
+| Parachute tangle | Proper packing, ground test | Failed recovery |
 
 ### 13.2 Risk Mitigation Through Testing
 
 | Test | Purpose | When |
 |------|---------|------|
-| Flight #2 (J420R) | Validate airframe, electronics, recovery | Before L flight |
+| Separation mechanism bench test | Verify servo releases pin, spring separates sections | During construction |
+| Redundancy test | Verify each system independently triggers separation | During construction |
+| Cold temperature test | Verify servo and spring operation at expected launch temps | During construction |
+| Vibration/shake test | Verify pins don't release under simulated flight loads | During construction |
+| Flight #2 (J420R) | Validate airframe, electronics, separation mechanism | Before L flight |
 | Flight #3 (L1000W) | Stress test at higher loads and speeds | Before M flight |
-| Ejection charge ground test | Verify charge sizes separate rocket | Before each flight |
 | Electronics ground test | Verify both systems detect apogee/altitude correctly | Before each flight |
 
 ### 13.3 Compliance
@@ -620,7 +674,7 @@ Electronic deployment count: 1 of 2 minimum complete.
 | FAR 101.25 | Altitude prediction within waiver |
 | Waiver radius | Wind simulation, dual deploy for tight landing |
 | Landing velocity ≤ 35 ft/s | Parachute sizing calculation |
-| Dual redundant electronics | Two independent systems |
+| Dual redundant electronics | Two independent systems with independent servos |
 | CP marked on rocket | External marking |
 
 ---
@@ -647,7 +701,17 @@ Electronic deployment count: 1 of 2 minimum complete.
 
 *TODO: Custom FC schematic, PCB layout, firmware overview*
 
-### F. Forms
+### F. Separation Mechanism Design
+
+*TODO: Detailed drawings of servo-actuated pin release mechanism, including:*
+
+- Pin geometry and shear strength analysis
+- Spring selection and force calculations
+- Servo selection and torque requirements
+- Redundancy solution (how either FC independently triggers release)
+- Assembly and preload procedure
+
+### G. Forms
 
 - [Universal Certification Form (UCF)](https://www.tripoli.org/docs.ashx?id=859597)
 - [Pre-Flight Data Capture Form](https://www.tripoli.org/docs.ashx?id=891494)

--- a/docs/certification/l3-design-document.md
+++ b/docs/certification/l3-design-document.md
@@ -55,7 +55,7 @@ Tripoli Level 3 high-power certification using a scratch-built rocket with a sin
 - Progressive flight testing on J and L motors before cert flight
 - 3D printed fin can in PC CF with carbon rod reinforcement for flutter resistance
 - Dual redundant electronics as required by Tripoli L3 rules
-- Servo-actuated spring release instead of black powder ejection charges — mechanism under evaluation (dual-half bayonet or hinged door)
+- Servo-actuated spring release instead of black powder ejection charges — mechanism under evaluation (C-hinge with lateral pins or dual-half bayonet)
 - Symmetric design: identical parts for both redundancy halves to simplify manufacturing and spares
 - Single-use motor to avoid reloadable hardware risk
 
@@ -220,6 +220,7 @@ The separation servos and their batteries must be located near the separation jo
 | Main parachute | TBD size | 1 | TBD |
 | Separation springs | TBD | TBD per joint | TBD |
 | Separation mechanism parts (printed) | Spectrum PC CF, identical parts | 2 per joint (4 total) | Printed by candidate |
+| Lateral pins | TBD (steel or carbon rod) | 2 per joint (4 total) | TBD |
 | Servo wall-hugging enclosures (printed) | Spectrum PC CF, matched to tube ID | 4 total (2 per joint) | Printed by candidate |
 | Servos (separation) | TBD | 4 total (1 per mechanism half) | TBD |
 | Tether cord (mechanism retention) | TBD | As needed | TBD |
@@ -253,17 +254,17 @@ Dual deployment using servo-actuated spring release mechanisms, controlled by du
 
 | Event | Altitude | Device | Action |
 |-------|----------|--------|--------|
-| Apogee | Apogee detection | Primary FC + Backup FC | Either servo releases its mechanism half → spring pushes parachute out → drogue deploys |
-| Main | TBD (e.g., 300m AGL) | Primary FC + Backup FC | Either servo releases its mechanism half → spring pushes parachute out → main deploys |
+| Apogee | Apogee detection | Primary FC + Backup FC | Either servo pulls its lateral pin → C-hinge separates → springs push sections apart → drogue deploys |
+| Main | TBD (e.g., 300m AGL) | Primary FC + Backup FC | Either servo pulls its lateral pin → C-hinge separates → springs push sections apart → main deploys |
 
 ### 4.2 Separation Mechanism Concept
 
 Instead of black powder ejection charges, separation is achieved mechanically:
 
-1. **Springs** are preloaded behind the parachute during assembly, providing deployment force
-2. **Retention mechanism** (two identical halves) holds the sections together against the spring preload during flight
-3. **Servos** release the mechanism halves on command from the flight computer
-4. Once either half is released, the remaining half cannot hold against the spring force alone, and the parachute is pushed out
+1. **Springs** are preloaded between body sections during assembly, providing separation force
+2. **Retention mechanism** (two identical C-hinge pairs at 180° apart) holds the sections together against the spring preload during flight
+3. **Servos** pull lateral pins on command from the flight computer
+4. Once either pin is pulled, the C-loops at that position fall apart — one remaining C-hinge pair cannot hold against the spring force alone → sections separate axially
 
 **Advantages over BP charges**:
 
@@ -276,81 +277,100 @@ Instead of black powder ejection charges, separation is achieved mechanically:
 
 Two leading candidates are under evaluation. Both share the same core principle: two identical halves per joint, each controlled by one FC system, either half's release alone causes separation. The selection will be made after prototyping and discussion with Rolf.
 
-#### Option A: Symmetric Dual-Half Bayonet
+#### Option A: C-Hinge with Lateral Pin (Preferred)
 
-The bayonet joint is split into two identical halves, positioned 180° apart. Each half is an independent latch controlled by its own servo and FC system.
+Interlocking C-shaped hinge loops at two positions 180° apart around the separation joint. Each C-hinge pair is held together by a lateral pin. The servo pulls the pin sideways to release.
 
 **Operating principle:**
 
 ```
-    LOCKED STATE                    EITHER HALF RELEASED
-    ┌──────────┐                    ┌──────────┐
-    │  Body A  │                    │  Body A  │
-    ├──┐    ┌──┤                    ├──┐       │
-    │H1│    │H2│  ← both halves    │H1│       │  ← half 2 released
-    ├──┘    └──┤    engaged         ├──┘       │    by servo #2
-    │  Body B  │                    │  Body B  │ ←── springs push apart
-    └──────────┘                    └──────────┘
+    CROSS-SECTION AT ONE C-HINGE PAIR
+
+    LOCKED (pin inserted)            RELEASED (pin pulled sideways)
+
+    Body A      Body B               Body A      Body B
+    ┌───┐       ┌───┐               ┌───┐       ┌───┐
+    │   ╰─╮ ╭─╯   │               │   ╰─╮   ╭─╯   │
+    │     │P│     │               │     │   │     │  ← C-loops separate,
+    │   ╭─╯ ╰─╮   │               │   ╭─╯   ╰─╮   │    nothing to interlock
+    └───┘       └───┘               └───┘       └───┘
+
+    P = lateral pin through           Pin pulled sideways by servo
+        interlocking C-loops          C-loops fall apart
+
+
+    FULL JOINT (top view, looking down into tube)
+
+         C-hinge #1 (FC #1)
+              ┌─┐
+         ╭────┤P├────╮
+        │    └─┘    │
+    Body A           Body A
+        │            │
+         ╰────┤P├────╯
+              └─┘
+         C-hinge #2 (FC #2)
+
+    Two C-hinge pairs at 180° apart
+    Each has its own lateral pin
+    Either pin removal → that pair falls apart → other pair can't hold → separation
 ```
 
+- **Locked**: Both C-hinge pairs engaged with lateral pins. Together they carry full flight loads (axial thrust, drag, bending). The interlocking C-loops transfer axial loads through the pin in shear
+- **Released**: Either servo pulls its pin sideways. The C-loops at that position have nothing to interlock around — they simply separate. One remaining C-hinge pair cannot resist the full spring preload → sections push apart axially
+- **Geometry guarantee**: Unlike the bayonet (which requires careful force-balancing between lug engagement and spring force), the C-hinge release is binary — with pin present, the loops interlock and carry load; with pin removed, there is physically nothing connecting the loops. No force engineering needed for the release
+
+**Key design properties:**
+
+| Property | Value |
+|----------|-------|
+| C-hinge pairs per joint | 2 (at 180° apart) |
+| Lateral pins per joint | 2 (one per C-hinge pair) |
+| Total C-hinge pairs | 4 (2 joints × 2 pairs) |
+| Total lateral pins | 4 |
+| Servos total | 4 (one per pin) |
+| Unique parts to design | **1 C-hinge half** (same part on both body sections, both joints) + **1 pin** |
+| FC #1 controls | Pin at C-hinge #1 (drogue joint) + Pin at C-hinge #1 (main joint) |
+| FC #2 controls | Pin at C-hinge #2 (drogue joint) + Pin at C-hinge #2 (main joint) |
+
+**Advantages:**
+
+- **Binary release**: Pin in = locked, pin out = separated. No force balancing, no partial engagement, no "can one half hold?" uncertainty. The geometry guarantees separation when a pin is removed
+- **Simple servo action**: Linear pin pull (sideways). No rotation, no twist, no complex mechanism. Servo arm pulls pin through a short linear stroke
+- **Strong when locked**: C-loops transfer axial load through the pin in shear. Pin shear strength is well-understood and easy to calculate
+- **Symmetric**: Same C-hinge part printed multiple times. Same pin used everywhere
+- **Full axial separation**: Body sections push apart completely, standard parachute deployment geometry
+- **No tube cutout**: Joint is at the separation plane, no weakening of the body tube
+
+**Concerns:**
+
+- **Pin extraction force**: Pin must slide out cleanly under servo pull. Friction, corrosion, or deformation under load could impede extraction. Smooth pin surface, correct tolerances, and lubrication needed. Pin should not be under compression when loaded axially (C-loop geometry should transfer loads through shear, not clamping)
+- **C-loop strength**: The printed C-loops must handle flight loads without cracking or deforming. Wall thickness, infill, and print orientation critical. PC CF should have adequate strength, but needs analysis
+- **Pin retention during flight**: Pin must not slide out under vibration or G-loads. Options: friction fit, slight taper, detent notch, or servo holding the pin in place. The pin pull direction should be perpendicular to the primary load direction (axial) so flight loads don't tend to push the pin out
+- **Servo torque**: Must overcome pin friction + any detent. Linear pull via servo arm — calculate required force and arm geometry
+- **Tolerances**: C-loops must interlock cleanly. 3D printing tolerance for the loop gap and pin hole diameter. Print and test iterate
+- **Cold weather**: Pin friction and servo performance at -10 to -20°C
+- **Tethering**: After pin extraction, the pin itself must be tethered (to the servo arm or enclosure). Released C-loop halves separate with the body sections they're attached to — inherently tethered
+
+#### Option B: Symmetric Dual-Half Bayonet (Alternative)
+
+The bayonet joint is split into two identical halves, positioned 180° apart. Each half is an independent rotary latch controlled by its own servo and FC system.
+
 - **Locked**: Both bayonet halves engaged. Together they carry full flight loads
-- **Released**: Either servo releases its half. One half alone cannot resist the spring preload → sections separate axially
+- **Released**: Either servo releases its half (rotary or linear disengage). One half alone cannot resist the spring preload → sections separate axially
 - Each half carries ~50% of axial load when both engaged, but cannot resist spring force alone
 
 **Advantages:**
 
-- Full axial separation — body sections push apart completely
+- Full axial separation
 - Bayonet lugs are strong load-bearing surfaces
 - One part design, print four copies
 
 **Concerns:**
 
-- Lug geometry is the critical design parameter — must hold flight loads with two halves but release under spring force with one half. Narrow design window
+- Lug geometry is the critical design parameter — must hold flight loads with two halves but release under spring force with one half. This is the key weakness vs. the C-hinge: the bayonet requires careful force-balancing between lug engagement depth and spring force, whereas the C-hinge release is binary (pin in/out)
 - Must not creep under vibration — needs detent or servo holding torque
-- Servo and battery must be housed inside parachute bay (wall-hugging enclosure, see section 2.9)
-- Bayonet parts stay in the bay after release — potential tangle with parachute. Tethering and routing needed
-
-#### Option B: Hinged Door
-
-A hatch/door section at each separation joint, with hinge pins on two opposing sides (180° apart). Each FC controls one hinge pin. Springs behind the parachute push it out through the opened door.
-
-**Operating principle:**
-
-```
-    LOCKED STATE               ONE PIN PULLED           BOTH PINS PULLED
-    ┌──────────┐               ┌──────────┐             ┌──────────┐
-    │  Body    │               │  Body    │             │  Body    │
-    │ P1 door P2│              │    door⟋  │            │   ____   │
-    │          │               │  swings   │             │  open    │
-    └──────────┘               │  open on  │             │  door    │
-                               │  P1 hinge │             │  detached│
-                               └──────────┘             └──────────┘
-    P1, P2 = hinge pins        P2 removed →             Both removed →
-    Both locked                door swings on P1         door free, springs
-                               Springs push chute out    push chute out
-```
-
-- **Locked**: Both hinge pins inserted. Door is held firmly closed. Pins carry flight loads in shear
-- **One pin pulled (single FC fires)**: Door swings open on the remaining hinge pin (which acts as the pivot). Springs push parachute out through the opening. The door stays attached via the remaining hinge — no tether needed for the door itself
-- **Both pins pulled (both FCs fire)**: Door detaches completely (tethered separately). Full opening
-
-**Advantages:**
-
-- Degraded mode is mechanically obvious and guaranteed — a door with one hinge removed *must* swing open under spring load. No careful "one half can't hold" engineering needed
-- The remaining hinge pin acts as both pivot and tether — door cannot become a separate falling object in the single-FC case
-- Simpler redundancy argument for TAP review: "pull either pin, door opens" is easy to demonstrate and explain
-- Springs push parachute out sideways through the hatch opening — spring force acts directly on parachute, not requiring full axial body separation
-- Servo and battery enclosures can be positioned near hinge pins, integrated into the door frame
-
-**Concerns:**
-
-- Body tube structural integrity — the door cutout weakens the tube. Need reinforcement around the hatch opening (thicker frame, doubler plate, or integrated printed frame)
-- Aerodynamic discontinuity — door edges and frame create surface irregularities. At subsonic speeds this may be acceptable but needs analysis
-- Door size — must be large enough for parachute to exit cleanly when pushed by springs. Parachute packing must account for sideways deployment
-- Hinge pin loads — pins carry flight loads in shear. Pin diameter and material must be sized for worst-case axial + bending loads
-- Spring arrangement — springs push parachute toward the door opening. Spring orientation and mount points differ from axial separation designs
-- Swing clearance — door must swing open without hitting launch rail, other body sections, or fin can
-- Two-pin-pulled case — door detaches, needs tether. Tether must not tangle with parachute
+- Bayonet parts stay in the bay after release — potential tangle with parachute
 
 #### Common Design Elements
 
@@ -358,8 +378,8 @@ Both options share:
 
 | Element | Description |
 |---------|-------------|
-| **Identical halves** | Same part printed twice per joint (bayonet halves or door+frame assemblies). One design, multiple prints |
-| **Spring deployment** | Preloaded springs push parachute out after release |
+| **Identical halves** | Same part printed multiple times. One design, multiple prints |
+| **Spring deployment** | Preloaded springs push body sections apart after release |
 | **Wall-hugging servo enclosures** | Servo + battery in smooth 3D printed fairings against tube wall (see section 2.9) |
 | **4 servos total** | One per mechanism half, 2 per joint, 2 joints |
 | **Tethering** | All released parts remain attached to a rocket section |
@@ -371,8 +391,8 @@ Applies to both mechanism options:
 
 | Scenario | Result |
 |----------|--------|
-| Both FCs fire normally | Both halves release → clean separation/opening |
-| FC #1 fires, FC #2 fails | Half A releases → separation (bayonet: one half can't hold; door: swings open on remaining hinge) |
+| Both FCs fire normally | Both halves release → clean separation |
+| FC #1 fires, FC #2 fails | Half A releases → separation (C-hinge: loops fall apart; bayonet: one half can't hold) |
 | FC #2 fires, FC #1 fails | Half B releases → separation (same logic) |
 | Both FCs fail | Both halves remain locked → no separation (ballistic) |
 | Servo #1 jams (mechanical) | FC #2 releases half B → separation |
@@ -382,25 +402,26 @@ True independent redundancy in both options: no single electrical or mechanical 
 
 ### 4.5 Mechanism Selection — TODO
 
-Decision criteria for selecting between Option A (bayonet) and Option B (hinged door):
+Decision criteria for selecting between Option A (C-hinge) and Option B (bayonet):
 
 1. **Prototype both** — print test versions of each, test fit and release on a body tube section
-2. **Structural analysis** — which is more robust under flight loads?
-3. **Reliability of degraded mode** — door swing-open is inherently more reliable than "one bayonet half can't hold." This favors Option B
-4. **Airframe impact** — bayonet requires no tube cutout; door weakens the tube. This favors Option A
-5. **Parachute deployment path** — axial (bayonet) vs. sideways through hatch (door). Which is more reliable?
-6. **TAP feedback** — discuss both with Rolf before committing
-7. **Ease of field assembly** — which is simpler to set up and verify at the launch site?
+2. **Release reliability** — C-hinge has binary release (pin in/out), bayonet requires force-balancing. This strongly favors Option A
+3. **Structural analysis** — compare load capacity of C-loops vs. bayonet lugs under flight loads
+4. **Pin extraction testing** — verify pin pulls cleanly under realistic conditions (load, cold, vibration)
+5. **TAP feedback** — discuss both with Rolf before committing
+6. **Ease of field assembly** — which is simpler to set up and verify at the launch site?
+
+Current preference: **Option A (C-hinge)** due to binary release guarantee.
 
 ### 4.6 Design Challenges — TODO
 
 Regardless of which mechanism is selected:
 
 - **Structural analysis**: Mechanism must handle boost loads (axial: motor thrust + drag, bending: wind loads, vibration: motor resonance)
-- **Spring force**: Must reliably push parachute out at all expected altitudes. Validated by ground testing
+- **Spring force**: Must reliably push sections apart and deploy parachute at all expected altitudes. Validated by ground testing
 - **Servo selection**: Must reliably actuate in cold weather (Swedish winter, -10 to -20°C at altitude), under vibration, after sustaining boost G-loads. Torque margin needed
 - **Tolerances**: 3D printed parts have different tolerances than machined parts. Test under realistic conditions, print spares
-- **Tethering**: All released parts must remain attached to a rocket section. No parts may descend without a recovery system (Tripoli non-certification condition)
+- **Tethering**: All released parts (pins, mechanism halves) must remain attached to a rocket section. No parts may descend without a recovery system (Tripoli non-certification condition)
 - **Wall-hugging enclosures**: Must not snag parachute or shock cord. Ground test with actual parachute packing
 - **Discuss with Rolf early**: Non-pyro separation is less common for L3. TAP approval of the concept is needed before detailed design
 
@@ -409,7 +430,7 @@ Regardless of which mechanism is selected:
 | Parameter | Value |
 |-----------|-------|
 | Trigger | Apogee detection (barometric) |
-| Mechanism | Servo-actuated release + spring deployment (TBD: bayonet or hinged door) |
+| Mechanism | Servo-actuated release + spring separation (TBD: C-hinge or bayonet) |
 | Parachute | TBD size drogue |
 | Descent rate under drogue | TBD m/s |
 | Separation point | TBD |
@@ -419,7 +440,7 @@ Regardless of which mechanism is selected:
 | Parameter | Value |
 |-----------|-------|
 | Trigger | Altitude-based (TBD meters AGL) |
-| Mechanism | Servo-actuated release + spring deployment (TBD: bayonet or hinged door) |
+| Mechanism | Servo-actuated release + spring separation (TBD: C-hinge or bayonet) |
 | Parachute | TBD size main |
 | Descent rate under main | TBD m/s (must not exceed 35 ft/s = 10.7 m/s per Tripoli rules) |
 | Separation point | TBD |
@@ -437,17 +458,17 @@ Regardless of which mechanism is selected:
 
 Per Tripoli L3 rules: *"Dual redundant electronics are required for all recovery events. Two completely independent and separate electronic recovery systems must be incorporated. Neither system must adversely affect the other. Redundancy means completely separate systems, including batteries, switches, avionics, and energetics."*
 
-With servo-actuated separation, "energetics" is replaced by servo + mechanism half + spring. Each system controls its own mechanism halves across both separation joints.
+With servo-actuated separation, "energetics" is replaced by servo + pin/mechanism + spring. Each system controls its own mechanism halves across both separation joints.
 
 | Component | Primary System (FC #1) | Backup System (FC #2) |
 |-----------|----------------------|---------------------|
 | Flight computer | Custom FC (CATS Vega clone, improved) | CATS Vega (original) or second custom clone |
 | Battery | Dedicated battery #1 | Dedicated battery #2 |
 | Arming switch | Key switch #1 | Key switch #2 |
-| Drogue release | Servo #1 → mechanism half A (drogue joint) | Servo #2 → mechanism half B (drogue joint) |
-| Main release | Servo #3 → mechanism half A (main joint) | Servo #4 → mechanism half B (main joint) |
+| Drogue release | Servo #1 → lateral pin at C-hinge #1 (drogue joint) | Servo #2 → lateral pin at C-hinge #2 (drogue joint) |
+| Main release | Servo #3 → lateral pin at C-hinge #1 (main joint) | Servo #4 → lateral pin at C-hinge #2 (main joint) |
 
-The two systems share no electrical connections. Each has independent power, switching, sensing, and servo output. Each controls one of the two identical mechanism halves at each joint. Either system alone triggers deployment.
+The two systems share no electrical connections. Each has independent power, switching, sensing, and servo output. Each controls one of the two identical C-hinge pairs at each joint. Either system alone triggers separation.
 
 ### 4.11 Motor Note
 
@@ -457,9 +478,10 @@ The M1350W-PS is a plugged motor — no motor ejection charge. All recovery depe
 
 The following approaches were evaluated earlier and set aside:
 
-- **Dual pin**: Two independent pins, each pulled by one servo. Simpler mechanically, but harder to ensure one pin alone cannot hold against springs while both together resist flight loads. Pin geometry is fussy
+- **Dual pin (without C-hinge)**: Two independent pins, each pulled by one servo. Simpler mechanically, but harder to ensure one pin alone cannot hold against springs while both together resist flight loads. The C-hinge solves this by making the release binary
 - **Single bayonet with dual servos**: One bayonet ring, two servos rotating it in opposite directions. Cleaner single mechanism, but a jammed bayonet blocks both systems — not truly independent failure paths
 - **Hybrid (bayonet + pin bypass)**: Primary via bayonet rotation, backup via pin pull releasing entire bayonet assembly. True mechanical independence, but asymmetric design — two different part types, more complex, tether management concerns
+- **Hinged door**: Hatch in body tube wall with hinge pins on two sides. Pull either pin → door swings open → parachute deploys sideways. Mechanically elegant degraded mode, but the tube cutout weakens structural integrity, creates aerodynamic discontinuity, and requires sideways parachute deployment which is non-standard. The C-hinge achieves the same binary release guarantee while maintaining full axial separation and no tube cutout
 
 ---
 
@@ -473,11 +495,11 @@ The following approaches were evaluated earlier and set aside:
 
 *TODO: Create wiring diagram showing:*
 
-- Battery #1 → Key switch #1 → Primary FC → Servo #1 (drogue half A) + Servo #3 (main half A)
-- Battery #2 → Key switch #2 → Backup FC → Servo #2 (drogue half B) + Servo #4 (main half B)
+- Battery #1 → Key switch #1 → Primary FC → Servo #1 (drogue C-hinge #1 pin) + Servo #3 (main C-hinge #1 pin)
+- Battery #2 → Key switch #2 → Backup FC → Servo #2 (drogue C-hinge #2 pin) + Servo #4 (main C-hinge #2 pin)
 - Physical separation between systems
 - Servo connections (signal + power)
-- Mechanical linkage to mechanism halves (conceptual)
+- Mechanical linkage: servo arm → pin pull (conceptual)
 
 ### 5.2 Primary System
 
@@ -485,8 +507,8 @@ The following approaches were evaluated earlier and set aside:
 |-----------|------|-----|
 | Power | Battery #1 (TBD V) | Key switch #1 |
 | Switched power | Key switch #1 | Primary FC power input |
-| Servo channel 1 | Primary FC drogue output | Servo #1 → drogue joint mechanism half A |
-| Servo channel 2 | Primary FC main output | Servo #3 → main joint mechanism half A |
+| Servo channel 1 | Primary FC drogue output | Servo #1 → pulls lateral pin at drogue C-hinge #1 |
+| Servo channel 2 | Primary FC main output | Servo #3 → pulls lateral pin at main C-hinge #1 |
 
 ### 5.3 Backup System
 
@@ -494,8 +516,8 @@ The following approaches were evaluated earlier and set aside:
 |-----------|------|-----|
 | Power | Battery #2 (TBD V) | Key switch #2 |
 | Switched power | Key switch #2 | Backup FC power input |
-| Servo channel 1 | Backup FC drogue output | Servo #2 → drogue joint mechanism half B |
-| Servo channel 2 | Backup FC main output | Servo #4 → main joint mechanism half B |
+| Servo channel 1 | Backup FC drogue output | Servo #2 → pulls lateral pin at drogue C-hinge #2 |
+| Servo channel 2 | Backup FC main output | Servo #4 → pulls lateral pin at main C-hinge #2 |
 
 ---
 
@@ -684,8 +706,8 @@ If flutter margin insufficient with PC CF alone:
 - [ ] Motor mount assembly
 - [ ] Centering ring installation
 - [ ] Body tube preparation
-- [ ] Separation mechanism prototype printing and testing (both options)
-- [ ] Mechanism selection (bayonet vs. hinged door) after prototyping
+- [ ] Separation mechanism prototype printing and testing (C-hinge and bayonet)
+- [ ] Mechanism selection after prototyping
 - [ ] Final mechanism parts printing and fit testing
 - [ ] Wall-hugging servo enclosure printing and fit testing
 - [ ] Electronics bay / nose cone electronics construction
@@ -735,7 +757,7 @@ Electronic deployment count: 1 of 2 minimum complete.
 - [ ] Igniter (FirstFire)
 - [ ] Batteries charged (2×, one per system)
 - [ ] Key switches and keys (2×)
-- [ ] Spare mechanism halves and servos
+- [ ] Spare C-hinge halves, pins, and servos
 - [ ] Tools for field assembly
 
 ### 12.2 At Launch Site — Before Assembly
@@ -754,11 +776,11 @@ Electronic deployment count: 1 of 2 minimum complete.
 - [ ] Pack drogue parachute
 - [ ] Pack main parachute
 - [ ] Preload separation springs
-- [ ] Engage both mechanism halves at drogue joint
-- [ ] Engage both mechanism halves at main joint
-- [ ] Verify mechanism engagement at both joints
-- [ ] Verify all tethers attached
-- [ ] Connect servo mechanisms
+- [ ] Engage C-hinge pairs and insert lateral pins at drogue joint
+- [ ] Engage C-hinge pairs and insert lateral pins at main joint
+- [ ] Verify pin engagement at both joints (visual + tactile check)
+- [ ] Verify all tethers attached (pins tethered to servo arms/enclosures)
+- [ ] Connect servo mechanisms to pins
 - [ ] Connect primary FC wiring and servos (#1, #3)
 - [ ] Connect backup FC wiring and servos (#2, #4)
 - [ ] Arm primary system (key switch #1)
@@ -770,7 +792,7 @@ Electronic deployment count: 1 of 2 minimum complete.
 
 ### 12.4 Post-Flight
 
-- [ ] Recover rocket (all parts)
+- [ ] Recover rocket (all parts, including pins)
 - [ ] Present to TAP as recovered
 - [ ] TAP inspects for excessive damage
 - [ ] TAP determines certification result
@@ -787,16 +809,16 @@ Electronic deployment count: 1 of 2 minimum complete.
 |-------------|------------|-------------|
 | Motor CATO | Single-use motor, proper assembly | Non-certification |
 | Motor retention failure | Adequate retention hardware, inspection | Non-certification |
-| Primary electronics failure | Backup system releases half B → deployment | Successful recovery |
-| Backup electronics failure | Primary system releases half A → deployment | Successful recovery |
+| Primary electronics failure | Backup system pulls pin at C-hinge #2 → separation | Successful recovery |
+| Backup electronics failure | Primary system pulls pin at C-hinge #1 → separation | Successful recovery |
 | Both electronics fail | Design for reliability, ground test | Non-certification (ballistic descent) |
-| Single servo failure | Other system's servo releases its half → deployment | Successful recovery |
-| Both servos fail on same joint | Ground testing, servo selection, cold testing | Failed deployment |
-| Mechanism half jammed | Tolerances, lubrication, testing, print spares; other half release still triggers deployment | Successful recovery (degraded) |
-| Spring insufficient | Ground testing at various temperatures, margin in spring force | Incomplete deployment |
-| Premature release (vibration/G) | Structural analysis, detent/pin design, vibration testing | Premature deployment during boost |
+| Single servo failure | Other system's servo pulls its pin → separation | Successful recovery |
+| Both servos fail on same joint | Ground testing, servo selection, cold testing | Failed separation |
+| Pin stuck (friction/deformation) | Smooth pin surface, lubrication, tolerances, cold testing; other pin still releases | Successful recovery (degraded) |
+| C-loop cracked/broken | PC CF strength analysis, print orientation, infill, test loads | Structural failure at joint |
+| Spring insufficient | Ground testing at various temperatures, margin in spring force | Incomplete separation |
+| Premature pin extraction (vibration/G) | Pin pull direction perpendicular to axial loads, detent, servo holding | Premature separation during boost |
 | Tether tangle with parachute | Tether routing, length management, ground test | Tangled recovery |
-| Body tube weakened by door cutout (Option B) | Reinforced frame, doubler plate, structural analysis | Structural failure |
 | Parachute snags on servo enclosure | Wall-hugging smooth fairing, ground test with actual packing | Failed deployment |
 | Fin flutter | Flutter analysis, carbon reinforcement, progressive test flights | Structural failure |
 | Unstable flight | Stability analysis, CP/CG verification, OpenRocket sim | Unsafe flight |
@@ -806,16 +828,17 @@ Electronic deployment count: 1 of 2 minimum complete.
 
 | Test | Purpose | When |
 |------|---------|------|
-| Mechanism prototype (Option A) | Print and test bayonet half engagement/release | Early prototyping |
-| Mechanism prototype (Option B) | Print and test hinged door engagement/release/swing | Early prototyping |
+| C-hinge prototype | Print and test C-loop engagement, pin insertion/extraction | Early prototyping |
+| Bayonet prototype | Print and test bayonet half engagement/release | Early prototyping |
 | Mechanism selection | Compare prototypes, select winner | After prototyping |
+| Pin extraction force measurement | Quantify force needed to pull pin under load and no-load | After mechanism selection |
 | Servo enclosure fit test | Verify parachute slides past without snagging | During construction |
-| Separation bench test (both halves) | Verify spring deploys parachute when both released | During construction |
-| Redundancy test (half A only) | Verify releasing half A alone causes deployment | During construction |
-| Redundancy test (half B only) | Verify releasing half B alone causes deployment | During construction |
+| Separation bench test (both pins) | Verify spring separates when both pins pulled | During construction |
+| Redundancy test (pin #1 only) | Verify pulling pin #1 alone causes separation | During construction |
+| Redundancy test (pin #2 only) | Verify pulling pin #2 alone causes separation | During construction |
 | Cold temperature test | Verify servo and mechanism operation at -10 to -20°C | During construction |
-| Vibration/shake test | Verify mechanism doesn't release under simulated flight loads | During construction |
-| Tether deployment test | Verify tethered parts don't tangle with parachute | During construction |
+| Vibration/shake test | Verify pins don't extract under simulated flight loads | During construction |
+| Tether deployment test | Verify tethered pins/parts don't tangle with parachute | During construction |
 | Flight #2 (J420R) | Validate airframe, electronics, separation mechanism in flight | Before L flight |
 | Flight #3 (L1000W) | Stress test at higher loads and speeds | Before M flight |
 | Electronics ground test | Verify both systems detect apogee/altitude correctly | Before each flight |
@@ -828,8 +851,8 @@ Electronic deployment count: 1 of 2 minimum complete.
 | FAR 101.25 | Altitude prediction within waiver |
 | Waiver radius | Wind simulation, dual deploy for tight landing |
 | Landing velocity ≤ 35 ft/s | Parachute sizing calculation |
-| Dual redundant electronics | Two independent systems, each controlling one mechanism half |
-| No untethered components | All mechanism parts tethered to rocket sections |
+| Dual redundant electronics | Two independent systems, each controlling one C-hinge pin |
+| No untethered components | All pins and mechanism parts tethered to rocket sections |
 | CP marked on rocket | External marking |
 
 ---
@@ -842,7 +865,7 @@ Electronic deployment count: 1 of 2 minimum complete.
 
 ### B. OpenSCAD Design Files
 
-*TODO: Include .scad source for fin can, fins, mechanism halves, and servo enclosures*
+*TODO: Include .scad source for fin can, fins, C-hinge halves, and servo enclosures*
 
 ### C. Thrust Curve Data
 
@@ -860,18 +883,19 @@ Electronic deployment count: 1 of 2 minimum complete.
 
 *TODO: Detailed drawings of selected separation mechanism, including:*
 
-- Mechanism half geometry (OpenSCAD parametric design)
-- Load analysis (engagement depth / hinge pin shear)
+- C-hinge loop geometry (OpenSCAD parametric design)
+- Lateral pin dimensions and material (shear strength analysis)
+- Pin extraction force analysis (friction, detent, servo torque margin)
 - Spring selection and force calculations
-- Servo selection and torque requirements
-- Anti-vibration design (detent / pin retention)
+- Servo selection and arm geometry for linear pin pull
+- Anti-vibration pin retention design
 - Wall-hugging servo enclosure design
-- Redundancy verification test results (each half independently)
-- Tether routing plan
+- Redundancy verification test results (each pin independently)
+- Tether routing plan (pins tethered to servo arms)
 - Assembly and preload procedure
 - Print settings and tolerance measurements
 - Cold weather test results
-- Prototype comparison results (bayonet vs. hinged door)
+- Prototype comparison results (C-hinge vs. bayonet)
 
 ### G. Forms
 

--- a/docs/certification/l3-design-document.md
+++ b/docs/certification/l3-design-document.md
@@ -1,0 +1,654 @@
+# L3 Certification Design Document
+
+**Candidate**: Tõnu Samuel (TRA# 38105)
+**TAP Member #1**: Rolf Örell (TRA# 3728)
+**TAP Member #2**: TBD
+**Date**: February 2026 (Draft)
+**Status**: DRAFT — Not yet submitted for TAP review
+
+---
+
+## Table of Contents
+
+1. [Project Overview](#1-project-overview)
+2. [Airframe Construction Details](#2-airframe-construction-details)
+3. [Bill of Materials](#3-bill-of-materials)
+4. [Recovery System](#4-recovery-system)
+5. [Recovery Electronics Schematic](#5-recovery-electronics-schematic)
+6. [Motor](#6-motor)
+7. [Stability Analysis](#7-stability-analysis)
+8. [Flight Simulations](#8-flight-simulations)
+9. [Fin Flutter Analysis](#9-fin-flutter-analysis)
+10. [Construction Documentation](#10-construction-documentation)
+11. [L2 Flight Log](#11-l2-flight-log)
+12. [Pre-Flight Checklist](#12-pre-flight-checklist)
+13. [Safety Analysis](#13-safety-analysis)
+
+---
+
+## 1. Project Overview
+
+### 1.1 Objective
+
+Tripoli Level 3 high-power certification using a scratch-built rocket with a single AeroTech M1350W-PS motor, dual-deployment recovery controlled by dual redundant electronics.
+
+### 1.2 Rocket Summary
+
+| Parameter | Value |
+|-----------|-------|
+| Name | TBD |
+| Designer/Builder | Tõnu Samuel |
+| Construction | Scratch-built |
+| Length | TBD |
+| Diameter | TBD |
+| Dry weight (no motor) | TBD |
+| Liftoff weight (with motor) | TBD |
+| Motor | AeroTech M1350W-PS (75mm, 5178 N-s) |
+| Recovery | Dual deploy, dual redundant electronics |
+| Expected altitude | TBD |
+| Number of fins | TBD |
+| Fin material | Spectrum PC CF (3D printed polycarbonate + carbon fiber) |
+
+### 1.3 Design Philosophy
+
+- Minimum motor class (barely M at 5178 N-s) to keep velocities and forces manageable
+- Progressive flight testing on J and L motors before cert flight
+- 3D printed fin can in PC CF with carbon rod reinforcement for flutter resistance
+- Dual redundant electronics as required by Tripoli L3 rules
+- Single-use motor to avoid reloadable hardware risk
+
+---
+
+## 2. Airframe Construction Details
+
+*Per Tripoli L3 requirement 1.a.i: Dimensioned drawings*
+
+### 2.1 General Arrangement Drawing
+
+*TODO: Dimensioned side-view drawing showing all major sections and dimensions*
+
+- Overall length
+- Body tube OD/ID
+- Nose cone length and shape
+- Fin dimensions and positions
+- CP and CG locations marked
+- Electronics bay location
+- Recovery section layout
+- Motor mount position and length
+
+### 2.2 Body Tube
+
+| Parameter | Value |
+|-----------|-------|
+| Material | TBD |
+| Outer diameter | TBD |
+| Inner diameter | TBD |
+| Wall thickness | TBD |
+| Total length | TBD |
+
+### 2.3 Nose Cone
+
+| Parameter | Value |
+|-----------|-------|
+| Type | TBD (ogive/Von Kármán/conical) |
+| Material | TBD (3D printed or commercial) |
+| Length | TBD |
+| Shoulder length | TBD |
+
+### 2.4 Fin Can Assembly
+
+The fin can is 3D printed by the candidate using OpenSCAD for parametric design and Bambu P1S for printing.
+
+| Parameter | Value |
+|-----------|-------|
+| Material | Spectrum PC CF (polycarbonate + carbon fiber) |
+| Number of fins | TBD |
+| Fin shape | TBD |
+| Root chord | TBD |
+| Tip chord | TBD |
+| Span | TBD |
+| Thickness | TBD |
+| Sweep angle | TBD |
+| Reinforcement | Carbon rod channels (2× per fin, at 25% and 60% chord) |
+| Infill | 70% |
+| Print orientation | TBD |
+
+**Multi-part assembly**: The fin can body is printed in multiple sections (each ≤250mm tall, Bambu P1S limit with AMS) and bonded together. Fins are printed individually and bonded to the assembled can.
+
+### 2.5 Centering Rings and Bulkheads
+
+| Component | Material | Dimensions | Notes |
+|-----------|----------|------------|-------|
+| Forward centering ring | TBD | TBD | |
+| Aft centering ring | TBD | TBD | |
+| E-bay forward bulkhead | TBD | TBD | |
+| E-bay aft bulkhead | TBD | TBD | |
+
+### 2.6 Motor Mount
+
+| Parameter | Value |
+|-----------|-------|
+| Motor tube ID | 75mm |
+| Motor tube material | TBD |
+| Length | TBD (≥622mm for M1350W-PS) |
+| Motor retention | TBD |
+
+### 2.7 Motor Adapters
+
+For pre-certification test flights:
+
+| Adapter | For Motor | Inner Diameter |
+|---------|-----------|----------------|
+| 75→54mm | AeroTech L1000W-18A | 54mm |
+| 75→38mm | AeroTech J420R | 38mm |
+
+### 2.8 Electronics Bay
+
+| Parameter | Value |
+|-----------|-------|
+| Location | TBD (typically mid-body between recovery sections) |
+| Length | TBD |
+| Sled material | TBD |
+| Switch access | External key switches (2×, one per system) |
+| Charge wells | 4× (2 drogue + 2 main, one per system) |
+
+### 2.9 Rail Guides
+
+| Parameter | Value |
+|-----------|-------|
+| Type | TBD |
+| Quantity | TBD |
+| Positions | TBD |
+
+---
+
+## 3. Bill of Materials
+
+*Per Tripoli L3 requirement 1.a.ii*
+
+### 3.1 Airframe Components
+
+| Item | Specification | Quantity | Source |
+|------|--------------|----------|--------|
+| Body tube | TBD | TBD | TBD |
+| Nose cone | TBD | 1 | TBD |
+| Fin can body (printed) | Spectrum PC CF | 1 set | Printed by candidate |
+| Fins (printed) | Spectrum PC CF | TBD | Printed by candidate |
+| Carbon reinforcement rods | 2.0mm carbon rod | TBD | TBD |
+| Centering rings | TBD | TBD | TBD |
+| Motor mount tube | 75mm ID | 1 | TBD |
+| Motor retainer | TBD | 1 | TBD |
+| E-bay sled | TBD | 1 | TBD |
+| Bulkheads | TBD | 2 | TBD |
+| Rail guides | TBD | TBD | TBD |
+| Shock cord | TBD | TBD | TBD |
+| Quick links / hardware | TBD | TBD | TBD |
+
+### 3.2 Recovery Components
+
+| Item | Specification | Quantity | Source |
+|------|--------------|----------|--------|
+| Drogue parachute | TBD size | 1 | TBD |
+| Main parachute | TBD size | 1 | TBD |
+| Nomex chute protectors | TBD | 2 | TBD |
+| Shear pins | TBD | TBD | TBD |
+| Ejection charges (BP) | TBD grams each | 4 (2 per system) | TBD |
+
+### 3.3 Electronics
+
+| Item | Specification | Quantity | Source |
+|------|--------------|----------|--------|
+| Primary flight computer | Custom (CATS Vega-based) | 1 | Built by candidate |
+| Backup flight computer | TBD | 1 | TBD |
+| Battery (primary) | TBD | 1 | TBD |
+| Battery (backup) | TBD | 1 | TBD |
+| Key switch (primary) | TBD | 1 | TBD |
+| Key switch (backup) | TBD | 1 | TBD |
+| E-matches / igniters | TBD | 4 | TBD |
+
+### 3.4 Motor
+
+| Item | Specification | Quantity | Source |
+|------|--------------|----------|--------|
+| AeroTech M1350W-PS | 75mm single-use DMS | 1 | TBD (requires L3 to purchase — sourced via TAP) |
+
+---
+
+## 4. Recovery System
+
+*Per Tripoli L3 recovery requirements: parachute recovery required, dual deployment allowed with apogee destabilization event*
+
+### 4.1 Recovery Architecture
+
+Dual deployment with dual redundant electronics:
+
+| Event | Altitude | Device | Action |
+|-------|----------|--------|--------|
+| Apogee | Apogee detection | Primary FC + Backup FC | Drogue parachute deployment |
+| Main | TBD (e.g., 300m AGL) | Primary FC + Backup FC | Main parachute deployment |
+
+### 4.2 Drogue Deployment
+
+| Parameter | Value |
+|-----------|-------|
+| Trigger | Apogee detection (barometric) |
+| Parachute | TBD size drogue |
+| Descent rate under drogue | TBD m/s |
+| Separation point | TBD |
+| Charge size | TBD grams BP (×2, one per system) |
+
+### 4.3 Main Deployment
+
+| Parameter | Value |
+|-----------|-------|
+| Trigger | Altitude-based (TBD meters AGL) |
+| Parachute | TBD size main |
+| Descent rate under main | TBD m/s (must not exceed 35 ft/s = 10.7 m/s per Tripoli rules) |
+| Separation point | TBD |
+| Charge size | TBD grams BP (×2, one per system) |
+
+### 4.4 Landing Velocity
+
+| Parameter | Value |
+|-----------|-------|
+| Maximum allowed | 35 ft/s (10.7 m/s) per Tripoli TUSC |
+| Expected landing velocity | TBD |
+| Liftoff weight | TBD |
+| Main parachute Cd | TBD |
+
+### 4.5 Redundancy Architecture
+
+Per Tripoli L3 rules: *"Dual redundant electronics are required for all recovery events. Two completely independent and separate electronic recovery systems must be incorporated. Neither system must adversely affect the other. Redundancy means completely separate systems, including batteries, switches, avionics, and energetics."*
+
+| Component | Primary System | Backup System |
+|-----------|---------------|---------------|
+| Flight computer | Custom FC #1 | TBD (Custom FC #2 or commercial) |
+| Battery | Dedicated battery #1 | Dedicated battery #2 |
+| Arming switch | Key switch #1 | Key switch #2 |
+| Drogue charge | Charge #1 | Charge #2 |
+| Main charge | Charge #3 | Charge #4 |
+
+The two systems share no electrical connections. Each has independent power, switching, sensing, and pyro output.
+
+### 4.6 Motor Note
+
+The M1350W-PS is a plugged motor — no motor ejection charge. All recovery depends entirely on the dual redundant electronic systems. There is no motor backup.
+
+---
+
+## 5. Recovery Electronics Schematic
+
+*Per Tripoli L3 requirement 1.a.iii: "A wiring diagram that accurately reflects the wiring provided by the candidate from the power source, switches, and ejection charges."*
+
+*Note: Schematics of the actual flight computer internals are NOT required — only the wiring from power source, through switches, to the flight computers and ejection charges.*
+
+### 5.1 Wiring Diagram
+
+*TODO: Create wiring diagram showing:*
+
+- Battery #1 → Key switch #1 → Primary FC → Drogue charge #1 + Main charge #1
+- Battery #2 → Key switch #2 → Backup FC → Drogue charge #2 + Main charge #2
+- Physical separation between systems
+- E-match connections
+- Charge well layout
+
+### 5.2 Primary System
+
+| Connection | From | To |
+|-----------|------|-----|
+| Power | Battery #1 (TBD V) | Key switch #1 |
+| Switched power | Key switch #1 | Primary FC power input |
+| Pyro channel 1 | Primary FC drogue output | E-match → drogue charge #1 |
+| Pyro channel 2 | Primary FC main output | E-match → main charge #1 |
+
+### 5.3 Backup System
+
+| Connection | From | To |
+|-----------|------|-----|
+| Power | Battery #2 (TBD V) | Key switch #2 |
+| Switched power | Key switch #2 | Backup FC power input |
+| Pyro channel 1 | Backup FC drogue output | E-match → drogue charge #2 |
+| Pyro channel 2 | Backup FC main output | E-match → main charge #2 |
+
+---
+
+## 6. Motor
+
+### 6.1 Motor Specifications
+
+| Parameter | Value |
+|-----------|-------|
+| Motor | AeroTech M1350W-PS |
+| Type | Single-use DMS (Plugged + Smoke) |
+| Diameter | 75mm |
+| Length | 622mm |
+| Total impulse | 5178 N-s (1% M-class) |
+| Average thrust | 1357 N |
+| Maximum thrust | 1766 N |
+| Burn time | 3.8 s |
+| Total weight | 4808 g |
+| Propellant | White Lightning |
+| Ejection | **Plugged — no ejection charge** |
+| Certification | TRA certified, June 2014 |
+
+### 6.2 Motor Retention
+
+| Parameter | Value |
+|-----------|-------|
+| Method | TBD |
+| Rating | Must retain motor under full thrust + ejection loads |
+
+### 6.3 Thrust-to-Weight Ratio
+
+| Parameter | Value |
+|-----------|-------|
+| Average thrust | 1357 N |
+| Liftoff weight | TBD kg |
+| Thrust-to-weight ratio | TBD (minimum 5:1 required) |
+
+---
+
+## 7. Stability Analysis
+
+### 7.1 Center of Gravity (CG)
+
+| Condition | CG Location (from nose tip) |
+|-----------|----------------------------|
+| Without motor | TBD |
+| With motor (loaded) | TBD |
+| With motor (burnout) | TBD |
+
+### 7.2 Center of Pressure (CP)
+
+| Method | CP Location (from nose tip) |
+|--------|----------------------------|
+| Barrowman method | TBD |
+| OpenRocket | TBD |
+
+### 7.3 Stability Margin
+
+| Condition | Margin (calibers) | Assessment |
+|-----------|--------------------|------------|
+| At launch (loaded) | TBD | Must be ≥1.0 cal |
+| At burnout | TBD | |
+
+*Note: CP must be marked on the rocket per Tripoli rules.*
+
+### 7.4 Rail Exit Velocity
+
+| Parameter | Value |
+|-----------|-------|
+| Rail length | TBD |
+| Rail exit velocity | TBD (must be sufficient for stable flight) |
+
+---
+
+## 8. Flight Simulations
+
+*Per Tripoli L3 requirement 1.a.iv*
+
+### 8.1 Simulation Software
+
+| Software | Version | Purpose |
+|----------|---------|---------|
+| OpenRocket | TBD | Primary flight simulation |
+
+### 8.2 Simulation Parameters
+
+| Parameter | Value |
+|-----------|-------|
+| Motor | AeroTech M1350W (thrust curve from ThrustCurve.org) |
+| Liftoff weight | TBD |
+| Launch rod length | TBD |
+| Launch angle | TBD |
+| Wind speed | TBD (simulate range of conditions) |
+
+### 8.3 Simulation Results
+
+| Parameter | Value |
+|-----------|-------|
+| Maximum altitude | TBD |
+| Maximum velocity | TBD |
+| Maximum Mach number | TBD |
+| Maximum acceleration | TBD |
+| Time to apogee | TBD |
+| Rail exit velocity | TBD |
+| Optimal drogue delay | N/A (electronic deployment) |
+| Landing distance (no wind) | TBD |
+| Landing distance (TBD m/s wind) | TBD |
+
+### 8.4 Thrust Curve
+
+*TODO: Include M1350W thrust curve plot*
+
+### 8.5 Altitude vs. Time Plot
+
+*TODO: Include simulation altitude plot*
+
+### 8.6 Velocity vs. Time Plot
+
+*TODO: Include simulation velocity plot (critical for flutter analysis)*
+
+### 8.7 Wind Sensitivity Analysis
+
+*TODO: Simulate at multiple wind speeds to verify landing within waiver radius*
+
+---
+
+## 9. Fin Flutter Analysis
+
+### 9.1 Maximum Airspeed
+
+From flight simulations:
+
+| Parameter | Value |
+|-----------|-------|
+| Max velocity | TBD m/s |
+| Mach at max velocity | TBD |
+| Altitude at max velocity | TBD |
+
+### 9.2 Material Properties
+
+| Property | Spectrum PC CF | Source |
+|----------|---------------|--------|
+| Elastic modulus (E) | TBD GPa | Datasheet / testing |
+| Density | TBD g/cm³ | Datasheet |
+| Poisson's ratio | TBD | Estimated |
+
+### 9.3 Fin Geometry
+
+| Parameter | Value |
+|-----------|-------|
+| Root chord (Cr) | TBD |
+| Tip chord (Ct) | TBD |
+| Semi-span (b) | TBD |
+| Thickness (t) | TBD |
+| Taper ratio (λ = Ct/Cr) | TBD |
+
+### 9.4 Flutter Speed Calculation
+
+*TODO: Calculate flutter speed using NACA/Air Force flutter boundary equation and compare to maximum expected airspeed. Target safety factor ≥2.0.*
+
+### 9.5 Carbon Rod Reinforcement
+
+If flutter margin insufficient with PC CF alone:
+
+| Parameter | Value |
+|-----------|-------|
+| Rod diameter | 2.0-2.2mm carbon |
+| Number per fin | 2 |
+| Positions | 25% and 60% chord |
+| Channel design | Span-wise, accessible from tab face |
+| Effect on flutter speed | TBD |
+
+---
+
+## 10. Construction Documentation
+
+*Per Tripoli L3 requirements: candidate shall personally assemble all assemblies, frequently communicate with TAPs, and provide photos of construction progress.*
+
+### 10.1 Construction Log
+
+*TODO: Dated entries with photos for each construction phase:*
+
+- [ ] Fin can 3D printing (OpenSCAD design → 3MF export → Bambu P1S print)
+- [ ] Fin printing and carbon rod installation
+- [ ] Fin can assembly (bonding sections and fins)
+- [ ] Motor mount assembly
+- [ ] Centering ring installation
+- [ ] Body tube preparation
+- [ ] Electronics bay construction
+- [ ] E-bay sled with dual flight computers
+- [ ] Wiring of dual redundant systems
+- [ ] Recovery harness assembly
+- [ ] Parachute packing
+- [ ] Final assembly
+- [ ] Weight and CG measurements
+- [ ] CP marking on airframe
+- [ ] Ground test of electronics
+- [ ] Ejection charge ground testing
+
+### 10.2 Construction Photos
+
+*TODO: Photos of candidate working on each assembly per Tripoli requirement*
+
+---
+
+## 11. L2 Flight Log
+
+*Per Tripoli L3 requirement: 3 flights on L2 impulse (J/K/L), at least 2 with electronic deployment. Submit with Tripoli L2-to-L3 Flight Log form.*
+
+| Flight | Date | Motor | Impulse | Electronic Deploy | Status |
+|--------|------|-------|---------|-------------------|--------|
+| 1 | 22 Feb 2026 | AeroTech J350 | J (658 N-s) | ✓ CATS Vega dual deploy | ✅ Complete |
+| 2 | TBD | AeroTech J420R | J (658 N-s) | ✓ Custom FC | Planned |
+| 3 | TBD | AeroTech L1000W | L (2714 N-s) | ✓ Custom FC | Planned |
+
+Electronic deployment count: 1 of 2 minimum complete.
+
+---
+
+## 12. Pre-Flight Checklist
+
+*Based on [Tripoli Pre-Flight Data Capture Form](https://www.tripoli.org/docs.ashx?id=891494) and [Pre-Flight Review Checklist](https://www.tripoli.org/content.aspx?page_id=22&club_id=795696&module_id=496546)*
+
+### 12.1 Before Leaving Home
+
+- [ ] Design packet (this document, approved and signed by both TAPs)
+- [ ] Signed Universal Certification Form (UCF) — top portion completed
+- [ ] Completed Pre-Flight Data Capture Form
+- [ ] L2-to-L3 Flight Log Form (with 3 flights documented)
+- [ ] Rocket fully assembled and inspected
+- [ ] Motor (M1350W-PS)
+- [ ] Igniter (FirstFire)
+- [ ] Ejection charges prepared (4×: 2 drogue + 2 main)
+- [ ] E-matches (4×)
+- [ ] Batteries charged (2×, one per system)
+- [ ] Key switches and keys (2×)
+- [ ] Tools for field assembly
+- [ ] Recovery wadding / Nomex protectors
+
+### 12.2 At Launch Site — Before Assembly
+
+- [ ] Present design packet to certifying TAP
+- [ ] Present completed Data Capture Form
+- [ ] TAP reviews predicted flight characteristics
+- [ ] Verify compliance with TUSC and FAR 101.25
+- [ ] Verify launch site dimensions support required safe distances
+
+### 12.3 Assembly and Arming
+
+- [ ] Assemble motor per instructions
+- [ ] TAP inspection of motor assembly
+- [ ] Install motor in rocket with retention
+- [ ] Pack drogue parachute
+- [ ] Pack main parachute
+- [ ] Install ejection charges (4×)
+- [ ] Install e-matches in charges
+- [ ] Connect primary FC wiring
+- [ ] Connect backup FC wiring
+- [ ] Arm primary system (key switch #1)
+- [ ] Verify primary FC status (LED/beep)
+- [ ] Arm backup system (key switch #2)
+- [ ] Verify backup FC status (LED/beep)
+- [ ] Final visual inspection
+- [ ] Place on launch rail
+
+### 12.4 Post-Flight
+
+- [ ] Recover rocket (all parts)
+- [ ] Present to TAP as recovered
+- [ ] TAP inspects for excessive damage
+- [ ] TAP determines certification result
+- [ ] If successful: TAP signs UCF
+- [ ] Candidate emails signed UCF to Tripoli HQ
+
+---
+
+## 13. Safety Analysis
+
+### 13.1 Failure Modes
+
+| Failure Mode | Mitigation | Consequence |
+|-------------|------------|-------------|
+| Motor CATO | Single-use motor, proper assembly | Non-certification |
+| Motor retention failure | Adequate retention hardware, inspection | Non-certification |
+| Primary electronics failure | Backup system fires charges | Successful recovery |
+| Backup electronics failure | Primary system fires charges | Successful recovery |
+| Both electronics fail | Design for reliability, ground test | Non-certification (ballistic descent) |
+| Fin flutter | Flutter analysis, carbon reinforcement, progressive test flights | Structural failure |
+| Unstable flight | Stability analysis, CP/CG verification, OpenRocket sim | Unsafe flight |
+| Parachute tangle | Proper packing, Nomex protectors, ground test | Failed recovery |
+| Shear pin failure (premature separation) | Correct shear pin sizing, ground test | Drag separation |
+| Ejection charge insufficient | Ground test charges, calculate volume | Failed deployment |
+| Ejection charge excessive | Ground test charges, calculate volume | Structural damage |
+
+### 13.2 Risk Mitigation Through Testing
+
+| Test | Purpose | When |
+|------|---------|------|
+| Flight #2 (J420R) | Validate airframe, electronics, recovery | Before L flight |
+| Flight #3 (L1000W) | Stress test at higher loads and speeds | Before M flight |
+| Ejection charge ground test | Verify charge sizes separate rocket | Before each flight |
+| Electronics ground test | Verify both systems detect apogee/altitude correctly | Before each flight |
+
+### 13.3 Compliance
+
+| Requirement | Compliance Method |
+|-------------|------------------|
+| Tripoli Unified Safety Code (TUSC) | Design review, simulation |
+| FAR 101.25 | Altitude prediction within waiver |
+| Waiver radius | Wind simulation, dual deploy for tight landing |
+| Landing velocity ≤ 35 ft/s | Parachute sizing calculation |
+| Dual redundant electronics | Two independent systems |
+| CP marked on rocket | External marking |
+
+---
+
+## Appendices
+
+### A. OpenRocket Simulation Files
+
+*TODO: Include .ork file or simulation output*
+
+### B. OpenSCAD Design Files
+
+*TODO: Include .scad source for fin can and fins*
+
+### C. Thrust Curve Data
+
+*TODO: Include M1350W RASP file from ThrustCurve.org*
+
+### D. Material Datasheets
+
+*TODO: Spectrum PC CF filament datasheet*
+
+### E. Flight Computer Documentation
+
+*TODO: Custom FC schematic, PCB layout, firmware overview*
+
+### F. Forms
+
+- [Universal Certification Form (UCF)](https://www.tripoli.org/docs.ashx?id=859597)
+- [Pre-Flight Data Capture Form](https://www.tripoli.org/docs.ashx?id=891494)
+- [L2 to L3 Flight Log Form](https://www.tripoli.org/docs.ashx?id=1566254)

--- a/docs/certification/l3-design-document.md
+++ b/docs/certification/l3-design-document.md
@@ -201,8 +201,9 @@ For pre-certification test flights:
 | Main parachute | TBD size | 1 | TBD |
 | Nomex chute protectors | TBD | 2 | TBD |
 | Separation springs | TBD | TBD | TBD |
-| Retention pins | TBD | TBD | TBD |
+| Separation mechanism hardware | TBD (pins/bayonet/hybrid) | TBD | TBD |
 | Servos (separation) | TBD | TBD | TBD |
+| Tether cord (mechanism retention) | TBD | TBD | TBD |
 
 ### 3.3 Electronics
 
@@ -235,17 +236,17 @@ Dual deployment using servo-actuated spring release mechanisms, controlled by du
 
 | Event | Altitude | Device | Action |
 |-------|----------|--------|--------|
-| Apogee | Apogee detection | Primary FC + Backup FC | Servo releases pin → spring separates body → drogue deploys |
-| Main | TBD (e.g., 300m AGL) | Primary FC + Backup FC | Servo releases pin → spring separates body → main deploys |
+| Apogee | Apogee detection | Primary FC + Backup FC | Servo releases mechanism → spring separates body → drogue deploys |
+| Main | TBD (e.g., 300m AGL) | Primary FC + Backup FC | Servo releases mechanism → spring separates body → main deploys |
 
 ### 4.2 Separation Mechanism Concept
 
 Instead of black powder ejection charges, separation is achieved mechanically:
 
 1. **Springs** are preloaded between body sections during assembly, providing separation force
-2. **Retention pins** hold the sections together against the spring preload during flight
-3. **Servos** pull the pins out on command from the flight computer
-4. Once pins are removed, springs push the sections apart and deploy the parachute
+2. **Retention mechanism** holds the sections together against the spring preload during flight
+3. **Servos** actuate the release mechanism on command from the flight computer
+4. Once released, springs push the sections apart and deploy the parachute
 
 **Advantages over BP charges**:
 
@@ -254,43 +255,75 @@ Instead of black powder ejection charges, separation is achieved mechanically:
 - No hot gas near parachutes — no Nomex protectors needed
 - Clean separation — no soot, no pressure spike
 
-**Design challenges — TODO**:
+### 4.3 Separation Mechanism Candidates
 
-- **Redundancy logic problem**: Tripoli requires each system to independently trigger recovery. This means each FC must be able to independently release the pins. But if two independent servos can each release, the pin retention is only as strong as the weaker servo holding mechanism. Need a design where:
-  - Either servo can independently release the pin (true redundancy)
-  - But the pin cannot accidentally release under flight loads (vibration, G-forces)
-  - And one servo failure does not jam the other servo's ability to release
-- **Possible approaches (all need analysis)**:
-  - Two pins per joint, each controlled by one servo — either pin removal destabilizes enough for separation, but both pins together handle flight loads
-  - Single pin with two independent pull mechanisms (e.g., two cables to same pin, either can pull it)
-  - Rotary latch with two independent release paths
-  - Other mechanisms TBD
-- **Pin structural requirements**: Pins must withstand aerodynamic loads, motor thrust loads, and vibration during boost without premature release. Shear strength analysis needed.
-- **Spring force**: Must be sufficient to overcome friction and reliably push sections apart and deploy parachute at all expected altitudes (varying air density). Must be validated by ground testing.
-- **Servo reliability**: Servo must reliably actuate in cold weather (Swedish winter conditions), under vibration, and after sustaining boost G-loads. Servo selection and testing critical.
-- **Discuss with Rolf early**: Non-pyro separation is less common for L3. TAP approval of the concept is needed before detailed design.
+The central design challenge is Tripoli's redundancy requirement: each FC must independently be able to trigger separation, while the mechanism must reliably hold during boost loads. Several candidate approaches are under consideration.
 
-### 4.3 Drogue Deployment
+#### Option A: Dual Pin
+
+Two independent pins per separation joint, each controlled by one servo (one per FC system). Each pin carries part of the flight loads.
+
+- **Release**: Either pin removal alone allows springs to push sections apart (pin geometry and spring force designed so one pin cannot hold against springs)
+- **Retention during flight**: Both pins together handle full aerodynamic and thrust loads
+- **Independence**: Each servo controls its own pin — no mechanical interaction
+- **Concern**: If one pin alone must NOT hold against the springs, each pin is only carrying partial load. Need to verify that vibration or G-forces cannot cause a single pin to slip. Careful geometry needed — tapered pins, detent depth, etc.
+
+#### Option B: Bayonet
+
+A bayonet-style rotary latch between body sections. Two servos are mounted on opposite sides, each capable of rotating the bayonet to the release position.
+
+- **Release**: Either servo rotates the bayonet to unlock position — both rotate in opposing directions so they don't fight each other
+- **Retention during flight**: Bayonet lugs carry full axial and bending loads in the locked position
+- **Independence**: Two servos acting on the same bayonet ring via opposing rotational inputs. Either one alone can unlock
+- **Advantages**: Strong retention in locked state (bayonet lugs are load-bearing surfaces), clean single-mechanism design, well-understood locking geometry
+- **Concerns**: Bayonet must rotate freely under all conditions (cold, vibration, slight misalignment). Binding under load is the main failure mode. Tolerances critical. Must not rotate under vibration alone — needs a detent or friction hold in the locked position that either servo can overcome
+
+#### Option C: Hybrid (Bayonet + Pin Bypass)
+
+Primary separation via bayonet (servo #1 rotates to unlock). Independent backup via pin pull (servo #2 pulls a pin that releases the entire bayonet mechanism from the body).
+
+- **Primary path (System 1)**: Servo rotates bayonet to unlock → springs separate
+- **Backup path (System 2)**: Servo pulls pin → bayonet assembly detaches from one body section entirely → springs separate. The released bayonet mechanism stays attached via tether cord to avoid separate falling parts
+- **Independence**: Two completely different mechanical paths to the same result. No shared failure modes between rotary and linear release
+- **Advantages**: True mechanical independence — a jammed bayonet doesn't prevent pin-pull separation. The pin bypass is a simple, robust backup
+- **Concerns**: More complex mechanism, more parts. Tether management (bayonet assembly must not tangle with parachute). Pin must hold under flight loads but release cleanly when pulled. Need to ensure the pin-pull path provides enough clearance for springs to push sections apart even with bayonet still partially engaged
+
+#### Tethering
+
+All separation mechanism hardware (pins, bayonet assemblies, servos) must remain attached to a rocket section via tether cords. No parts may descend without a recovery system — this is a Tripoli non-certification condition ("components which descend without a recovery system").
+
+### 4.4 Design Challenges — TODO
+
+Regardless of which mechanism is selected:
+
+- **Redundancy logic**: Must satisfy Tripoli requirement that each system independently triggers recovery, without creating a mechanism that is too easy to release accidentally
+- **Structural analysis**: Retention mechanism must handle boost loads (axial: motor thrust + drag, bending: wind loads, vibration: motor resonance). Analysis needed for the selected mechanism
+- **Spring force**: Must reliably push sections apart and deploy parachute at all expected altitudes. Validated by ground testing
+- **Servo selection**: Must reliably actuate in cold weather (Swedish winter), under vibration, after sustaining boost G-loads. Torque margin needed
+- **Tolerances**: 3D printed mechanism parts have different tolerances than machined parts. If mechanism is printed, test under realistic conditions
+- **Discuss with Rolf early**: Non-pyro separation is less common for L3. TAP approval of the concept is needed before detailed design
+
+### 4.5 Drogue Deployment
 
 | Parameter | Value |
 |-----------|-------|
 | Trigger | Apogee detection (barometric) |
-| Mechanism | Servo-actuated pin release + spring separation |
+| Mechanism | Servo-actuated release + spring separation |
 | Parachute | TBD size drogue |
 | Descent rate under drogue | TBD m/s |
 | Separation point | TBD |
 
-### 4.4 Main Deployment
+### 4.6 Main Deployment
 
 | Parameter | Value |
 |-----------|-------|
 | Trigger | Altitude-based (TBD meters AGL) |
-| Mechanism | Servo-actuated pin release + spring separation |
+| Mechanism | Servo-actuated release + spring separation |
 | Parachute | TBD size main |
 | Descent rate under main | TBD m/s (must not exceed 35 ft/s = 10.7 m/s per Tripoli rules) |
 | Separation point | TBD |
 
-### 4.5 Landing Velocity
+### 4.7 Landing Velocity
 
 | Parameter | Value |
 |-----------|-------|
@@ -299,25 +332,23 @@ Instead of black powder ejection charges, separation is achieved mechanically:
 | Liftoff weight | TBD |
 | Main parachute Cd | TBD |
 
-### 4.6 Redundancy Architecture
+### 4.8 Redundancy Architecture
 
 Per Tripoli L3 rules: *"Dual redundant electronics are required for all recovery events. Two completely independent and separate electronic recovery systems must be incorporated. Neither system must adversely affect the other. Redundancy means completely separate systems, including batteries, switches, avionics, and energetics."*
 
-Note: "energetics" in the Tripoli rules refers to ejection charges. With servo-actuated separation, the equivalent is the servo + pin + spring mechanism. Each system must independently be capable of triggering separation.
+Note: "energetics" in the Tripoli rules refers to ejection charges. With servo-actuated separation, the equivalent is the servo + mechanism + spring system. Each system must independently be capable of triggering separation.
 
 | Component | Primary System | Backup System |
 |-----------|---------------|---------------|
 | Flight computer | Custom FC (CATS Vega clone, improved) | CATS Vega (original) or second custom clone |
 | Battery | Dedicated battery #1 | Dedicated battery #2 |
 | Arming switch | Key switch #1 | Key switch #2 |
-| Drogue release | Servo #1 → pin/mechanism | Servo #2 → pin/mechanism |
-| Main release | Servo #3 → pin/mechanism | Servo #4 → pin/mechanism |
+| Drogue release | Servo #1 → mechanism path A | Servo #2 → mechanism path B |
+| Main release | Servo #3 → mechanism path A | Servo #4 → mechanism path B |
 
-The two systems share no electrical connections. Each has independent power, switching, sensing, and servo output.
+The two systems share no electrical connections. Each has independent power, switching, sensing, and servo output. The mechanical release paths are designed so either system alone can trigger separation (see section 4.3 for mechanism options).
 
-*TODO: Design the mechanical interface so that either servo can independently cause separation without the other. See section 4.2 design challenges.*
-
-### 4.7 Motor Note
+### 4.9 Motor Note
 
 The M1350W-PS is a plugged motor — no motor ejection charge. All recovery depends entirely on the dual redundant electronic systems. There is no motor backup.
 
@@ -337,7 +368,7 @@ The M1350W-PS is a plugged motor — no motor ejection charge. All recovery depe
 - Battery #2 → Key switch #2 → Backup FC → Drogue servo #2 + Main servo #2
 - Physical separation between systems
 - Servo connections (signal + power)
-- Mechanical linkage to pins (conceptual)
+- Mechanical linkage to release mechanism (conceptual)
 
 ### 5.2 Primary System
 
@@ -345,8 +376,8 @@ The M1350W-PS is a plugged motor — no motor ejection charge. All recovery depe
 |-----------|------|-----|
 | Power | Battery #1 (TBD V) | Key switch #1 |
 | Switched power | Key switch #1 | Primary FC power input |
-| Servo channel 1 | Primary FC drogue output | Servo #1 → drogue pin release |
-| Servo channel 2 | Primary FC main output | Servo #3 → main pin release |
+| Servo channel 1 | Primary FC drogue output | Servo #1 → drogue release path A |
+| Servo channel 2 | Primary FC main output | Servo #3 → main release path A |
 
 ### 5.3 Backup System
 
@@ -354,8 +385,8 @@ The M1350W-PS is a plugged motor — no motor ejection charge. All recovery depe
 |-----------|------|-----|
 | Power | Battery #2 (TBD V) | Key switch #2 |
 | Switched power | Key switch #2 | Backup FC power input |
-| Servo channel 1 | Backup FC drogue output | Servo #2 → drogue pin release |
-| Servo channel 2 | Backup FC main output | Servo #4 → main pin release |
+| Servo channel 1 | Backup FC drogue output | Servo #2 → drogue release path B |
+| Servo channel 2 | Backup FC main output | Servo #4 → main release path B |
 
 ---
 
@@ -550,7 +581,7 @@ If flutter margin insufficient with PC CF alone:
 - [ ] Servo mechanism installation and testing
 - [ ] Recovery harness assembly
 - [ ] Parachute packing
-- [ ] Spring preload and pin retention testing
+- [ ] Spring preload and retention mechanism testing
 - [ ] Final assembly
 - [ ] Weight and CG measurements
 - [ ] CP marking on airframe
@@ -611,8 +642,9 @@ Electronic deployment count: 1 of 2 minimum complete.
 - [ ] Pack drogue parachute
 - [ ] Pack main parachute
 - [ ] Preload separation springs
-- [ ] Install retention pins
-- [ ] Verify pin engagement
+- [ ] Engage retention mechanism (pins/bayonet)
+- [ ] Verify mechanism engagement
+- [ ] Verify tethers attached
 - [ ] Connect servo mechanisms
 - [ ] Connect primary FC wiring and servos
 - [ ] Connect backup FC wiring and servos
@@ -642,14 +674,15 @@ Electronic deployment count: 1 of 2 minimum complete.
 |-------------|------------|-------------|
 | Motor CATO | Single-use motor, proper assembly | Non-certification |
 | Motor retention failure | Adequate retention hardware, inspection | Non-certification |
-| Primary electronics failure | Backup system actuates servos | Successful recovery |
-| Backup electronics failure | Primary system actuates servos | Successful recovery |
+| Primary electronics failure | Backup system actuates servos via independent path | Successful recovery |
+| Backup electronics failure | Primary system actuates servos via independent path | Successful recovery |
 | Both electronics fail | Design for reliability, ground test | Non-certification (ballistic descent) |
-| Servo failure (single) | Redundant servo on other system releases same joint | Successful recovery |
+| Servo failure (single) | Redundant servo on other system releases via independent mechanical path | Successful recovery |
 | Servo failure (both on same joint) | Ground testing, servo selection, cold testing | Failed separation |
-| Pin jammed | Design for clean release, lubrication, vibration testing | Failed separation |
+| Mechanism jammed (bayonet binding / pin stuck) | Tolerances, lubrication, vibration testing; hybrid option provides alternate path | Failed separation |
 | Spring insufficient | Ground testing at various temperatures, margin in spring force | Incomplete separation |
-| Premature pin release (vibration/G) | Pin shear strength analysis, locking mechanism | Drag separation during boost |
+| Premature release (vibration/G) | Structural analysis, detent design, locking geometry | Drag separation during boost |
+| Tether tangle with parachute | Tether routing, length management, ground test | Tangled recovery |
 | Fin flutter | Flutter analysis, carbon reinforcement, progressive test flights | Structural failure |
 | Unstable flight | Stability analysis, CP/CG verification, OpenRocket sim | Unsafe flight |
 | Parachute tangle | Proper packing, ground test | Failed recovery |
@@ -658,11 +691,13 @@ Electronic deployment count: 1 of 2 minimum complete.
 
 | Test | Purpose | When |
 |------|---------|------|
-| Separation mechanism bench test | Verify servo releases pin, spring separates sections | During construction |
-| Redundancy test | Verify each system independently triggers separation | During construction |
-| Cold temperature test | Verify servo and spring operation at expected launch temps | During construction |
-| Vibration/shake test | Verify pins don't release under simulated flight loads | During construction |
-| Flight #2 (J420R) | Validate airframe, electronics, separation mechanism | Before L flight |
+| Separation mechanism bench test | Verify servo releases mechanism, spring separates sections | During construction |
+| Redundancy test (path A only) | Verify primary system alone triggers separation | During construction |
+| Redundancy test (path B only) | Verify backup system alone triggers separation | During construction |
+| Cold temperature test | Verify servo and mechanism operation at expected launch temps | During construction |
+| Vibration/shake test | Verify mechanism doesn't release under simulated flight loads | During construction |
+| Tether deployment test | Verify mechanism hardware doesn't tangle with parachute | During construction |
+| Flight #2 (J420R) | Validate airframe, electronics, separation mechanism in flight | Before L flight |
 | Flight #3 (L1000W) | Stress test at higher loads and speeds | Before M flight |
 | Electronics ground test | Verify both systems detect apogee/altitude correctly | Before each flight |
 
@@ -674,7 +709,8 @@ Electronic deployment count: 1 of 2 minimum complete.
 | FAR 101.25 | Altitude prediction within waiver |
 | Waiver radius | Wind simulation, dual deploy for tight landing |
 | Landing velocity ≤ 35 ft/s | Parachute sizing calculation |
-| Dual redundant electronics | Two independent systems with independent servos |
+| Dual redundant electronics | Two independent systems with independent mechanical release paths |
+| No untethered components | All mechanism parts tethered to rocket sections |
 | CP marked on rocket | External marking |
 
 ---
@@ -703,13 +739,17 @@ Electronic deployment count: 1 of 2 minimum complete.
 
 ### F. Separation Mechanism Design
 
-*TODO: Detailed drawings of servo-actuated pin release mechanism, including:*
+*TODO: Detailed drawings of selected separation mechanism, including:*
 
-- Pin geometry and shear strength analysis
+- Mechanism selection rationale (Option A/B/C from section 4.3)
+- Detailed drawings with dimensions
+- Structural analysis of retention under flight loads
 - Spring selection and force calculations
 - Servo selection and torque requirements
-- Redundancy solution (how either FC independently triggers release)
+- Redundancy verification (both paths independently tested)
+- Tether routing plan
 - Assembly and preload procedure
+- 3D printing considerations (if mechanism is printed)
 
 ### G. Forms
 

--- a/docs/certification/l3-design-document.md
+++ b/docs/certification/l3-design-document.md
@@ -266,12 +266,19 @@ Instead of black powder ejection charges, separation is achieved mechanically:
 3. **Servos** pull lateral pins on command from the flight computer
 4. Once either pin is pulled, the C-loops at that position fall apart — one remaining C-hinge pair cannot hold against the spring force alone → sections separate axially
 
-**Advantages over BP charges**:
+**Why not black powder ejection charges?**
 
-- No pyrotechnics — simpler handling, no e-matches, no charge sizing
-- Repeatable and testable — same force every time
+The conventional approach for HPR recovery separation uses black powder (BP) ejection charges. This design uses mechanical separation instead, for two reasons:
+
+1. **Legal constraint (Estonia)**: Black powder is classified as an explosive under Estonian law. The candidate has no legal basis to possess even small quantities. Rocket motors are classified separately as pyrotechnics and are legally permissible. This is a hard constraint — BP-based separation is not an option for a builder based in Estonia
+2. **Electronics protection**: BP charges deposit soot and combustion residue throughout the recovery bay. This rocket carries custom-built flight computers that are expensive and difficult to replace. Mechanical separation keeps the interior clean
+
+**Additional advantages of mechanical separation**:
+
+- Repeatable and testable — same force every time, no charge sizing uncertainty
 - No hot gas near parachutes — no Nomex protectors needed
-- Clean separation — no soot, no pressure spike
+- No e-matches — simpler wiring, no igniter reliability concerns
+- No pressure spike — gentler on airframe and recovery harness
 
 ### 4.3 Separation Mechanism Candidates
 

--- a/docs/certification/l3-design-document.md
+++ b/docs/certification/l3-design-document.md
@@ -55,7 +55,7 @@ Tripoli Level 3 high-power certification using a scratch-built rocket with a sin
 - Progressive flight testing on J and L motors before cert flight
 - 3D printed fin can in PC CF with carbon rod reinforcement for flutter resistance
 - Dual redundant electronics as required by Tripoli L3 rules
-- Servo-actuated spring release instead of black powder ejection charges — mechanism under evaluation (C-hinge with lateral pins or dual-half bayonet)
+- Servo-actuated spring release instead of black powder ejection charges — mechanism under evaluation (C-latch with tongue or dual-half bayonet)
 - Symmetric design: identical parts for both redundancy halves to simplify manufacturing and spares
 - Single-use motor to avoid reloadable hardware risk
 
@@ -219,10 +219,10 @@ The separation servos and their batteries must be located near the separation jo
 | Drogue parachute | TBD size | 1 | TBD |
 | Main parachute | TBD size | 1 | TBD |
 | Separation springs | TBD | TBD per joint | TBD |
-| Separation mechanism parts (printed) | Spectrum PC CF, identical parts | 2 per joint (4 total) | Printed by candidate |
-| Lateral pins | TBD (steel or carbon rod) | 2 per joint (4 total) | TBD |
+| C-hooks (printed) | Spectrum PC CF, identical parts | 2 per joint (4 total) | Printed by candidate |
+| Tongues (printed) | Spectrum PC CF, servo-actuated | 2 per joint (4 total) | Printed by candidate |
 | Servo wall-hugging enclosures (printed) | Spectrum PC CF, matched to tube ID | 4 total (2 per joint) | Printed by candidate |
-| Servos (separation) | TBD | 4 total (1 per mechanism half) | TBD |
+| Servos (separation) | TBD | 4 total (1 per tongue) | TBD |
 | Tether cord (mechanism retention) | TBD | As needed | TBD |
 
 ### 3.3 Electronics
@@ -254,17 +254,17 @@ Dual deployment using servo-actuated spring release mechanisms, controlled by du
 
 | Event | Altitude | Device | Action |
 |-------|----------|--------|--------|
-| Apogee | Apogee detection | Primary FC + Backup FC | Either servo pulls its lateral pin → C-hinge separates → springs push sections apart → drogue deploys |
-| Main | TBD (e.g., 300m AGL) | Primary FC + Backup FC | Either servo pulls its lateral pin → C-hinge separates → springs push sections apart → main deploys |
+| Apogee | Apogee detection | Primary FC + Backup FC | Either servo retracts its tongue → C-hook opens → springs push sections apart → drogue deploys |
+| Main | TBD (e.g., 300m AGL) | Primary FC + Backup FC | Either servo retracts its tongue → C-hook opens → springs push sections apart → main deploys |
 
 ### 4.2 Separation Mechanism Concept
 
 Instead of black powder ejection charges, separation is achieved mechanically:
 
 1. **Springs** are preloaded between body sections during assembly, providing separation force
-2. **Retention mechanism** (two identical C-hinge pairs at 180° apart) holds the sections together against the spring preload during flight
-3. **Servos** pull lateral pins on command from the flight computer
-4. Once either pin is pulled, the C-loops at that position fall apart — one remaining C-hinge pair cannot hold against the spring force alone → sections separate axially
+2. **Retention mechanism** (two identical C-latches at 180° apart) holds the sections together against the spring preload during flight
+3. **Servos** retract tongues on command from the flight computer
+4. Once either tongue is retracted, the C-hook at that position is an open hook holding nothing — one remaining C-latch cannot hold against the spring force alone → sections separate axially
 
 **Why not black powder ejection charges?**
 
@@ -284,80 +284,93 @@ The conventional approach for HPR recovery separation uses black powder (BP) eje
 
 Two leading candidates are under evaluation. Both share the same core principle: two identical halves per joint, each controlled by one FC system, either half's release alone causes separation. The selection will be made after prototyping and discussion with Rolf.
 
-#### Option A: C-Hinge with Lateral Pin (Preferred)
+#### Option A: C-Latch with Tongue (Preferred)
 
-Interlocking C-shaped hinge loops at two positions 180° apart around the separation joint. Each C-hinge pair is held together by a lateral pin. The servo pulls the pin sideways to release.
+A tongue-and-groove style latch. At the separation joint, C-shaped hooks are fixed to the body sections, opening toward each other. A servo-actuated tongue fills the gap in each C-hook, locking it closed. The servo retracts the tongue to release. The analogy is a door with two locks on opposite sides and no hinges — open either lock and the whole thing falls apart.
 
 **Operating principle:**
 
 ```
-    CROSS-SECTION AT ONE C-HINGE PAIR
+    SIDE VIEW — CROSS-SECTION AT ONE C-LATCH
+    (looking at the tube wall from inside)
 
-    LOCKED (pin inserted)            RELEASED (pin pulled sideways)
+    LOCKED (tongue inserted)          RELEASED (tongue retracted)
 
-    Body A      Body B               Body A      Body B
-    ┌───┐       ┌───┐               ┌───┐       ┌───┐
-    │   ╰─╮ ╭─╯   │               │   ╰─╮   ╭─╯   │
-    │     │P│     │               │     │   │     │  ← C-loops separate,
-    │   ╭─╯ ╰─╮   │               │   ╭─╯   ╰─╮   │    nothing to interlock
-    └───┘       └───┘               └───┘       └───┘
+    Body A       Body B               Body A       Body B
+    ┌────┐       ┌────┐              ┌────┐       ┌────┐
+    │    └─┐ ┌─┘    │              │    └─┐ ┌─┘    │
+    │      │T│      │              │      │ │      │  ← C-hooks are open,
+    │    ┌─┘ └─┐    │              │    ┌─┘ └─┐    │    nothing bridges them
+    └────┘       └────┘              └────┘       └────┘
 
-    P = lateral pin through           Pin pulled sideways by servo
-        interlocking C-loops          C-loops fall apart
+    C-hooks: passive, fixed to body sections, opening toward each other
+    T = tongue: servo-actuated, fills the C-gap to lock
+    Servo retracts tongue sideways → C-hooks have open mouths → sections separate
 
 
-    FULL JOINT (top view, looking down into tube)
+    TOP VIEW — FULL JOINT (looking down into tube)
 
-         C-hinge #1 (FC #1)
-              ┌─┐
-         ╭────┤P├────╮
-        │    └─┘    │
-    Body A           Body A
-        │            │
-         ╰────┤P├────╯
-              └─┘
-         C-hinge #2 (FC #2)
+                 C-latch #1 (FC #1)
+                    ┌─┐
+              ╭─────┤T├─────╮
+             │     └─┘     │
+         Body A             Body B
+             │     ┌─┐     │
+              ╰─────┤T├─────╯
+                    └─┘
+                 C-latch #2 (FC #2)
 
-    Two C-hinge pairs at 180° apart
-    Each has its own lateral pin
-    Either pin removal → that pair falls apart → other pair can't hold → separation
+    Two C-latches at 180° apart
+    Each has its own servo-actuated tongue
+    Either tongue retracted → that C-hook is open → other latch can't hold → separation
 ```
 
-- **Locked**: Both C-hinge pairs engaged with lateral pins. Together they carry full flight loads (axial thrust, drag, bending). The interlocking C-loops transfer axial loads through the pin in shear
-- **Released**: Either servo pulls its pin sideways. The C-loops at that position have nothing to interlock around — they simply separate. One remaining C-hinge pair cannot resist the full spring preload → sections push apart axially
-- **Geometry guarantee**: Unlike the bayonet (which requires careful force-balancing between lug engagement and spring force), the C-hinge release is binary — with pin present, the loops interlock and carry load; with pin removed, there is physically nothing connecting the loops. No force engineering needed for the release
+**Terminology:**
+
+| Term | Description |
+|------|-------------|
+| **C-hook** | Passive C-shaped bracket fixed to a body section. The open mouth faces the mating body section. Carries axial load only when the tongue is present to close the gap |
+| **Tongue** | Servo-actuated piece that fills the C-hook gap, closing it into a closed loop. Connected to the servo arm. When retracted, the C-hook is an open hook holding nothing |
+| **C-latch** | One complete latch assembly: two opposing C-hooks (one per body section) + one tongue + one servo. Two C-latches per joint, at 180° apart |
+
+**How it works:**
+
+- **Locked**: Tongue fills the C-hook gap on both sides. The C-hooks on Body A and Body B face each other with the tongue bridging both, creating a closed structural loop. Axial loads (thrust, drag) are transferred through the C-hook walls and tongue in compression/shear
+- **Released**: Servo retracts the tongue sideways. Both C-hooks at that position now have open mouths — there is nothing connecting Body A to Body B at that point. Like removing a lock from a door with no hinges: one remaining lock on the opposite side cannot hold the door against the spring preload → sections push apart axially
+- **Binary release guarantee**: Tongue in = closed loop carrying load. Tongue out = open hooks holding nothing. No force-balancing needed. The geometry guarantees separation when the tongue is retracted
 
 **Key design properties:**
 
 | Property | Value |
 |----------|-------|
-| C-hinge pairs per joint | 2 (at 180° apart) |
-| Lateral pins per joint | 2 (one per C-hinge pair) |
-| Total C-hinge pairs | 4 (2 joints × 2 pairs) |
-| Total lateral pins | 4 |
-| Servos total | 4 (one per pin) |
-| Unique parts to design | **1 C-hinge half** (same part on both body sections, both joints) + **1 pin** |
-| FC #1 controls | Pin at C-hinge #1 (drogue joint) + Pin at C-hinge #1 (main joint) |
-| FC #2 controls | Pin at C-hinge #2 (drogue joint) + Pin at C-hinge #2 (main joint) |
+| C-latches per joint | 2 (at 180° apart) |
+| Tongues per joint | 2 (one per C-latch, servo-actuated) |
+| Total C-latches | 4 (2 joints × 2 latches) |
+| Total tongues | 4 |
+| Servos total | 4 (one per tongue) |
+| Unique parts to design | **1 C-hook** (same part on both body sections) + **1 tongue** (connected to servo arm) |
+| FC #1 controls | Tongue at C-latch #1 (drogue joint) + Tongue at C-latch #1 (main joint) |
+| FC #2 controls | Tongue at C-latch #2 (drogue joint) + Tongue at C-latch #2 (main joint) |
 
 **Advantages:**
 
-- **Binary release**: Pin in = locked, pin out = separated. No force balancing, no partial engagement, no "can one half hold?" uncertainty. The geometry guarantees separation when a pin is removed
-- **Simple servo action**: Linear pin pull (sideways). No rotation, no twist, no complex mechanism. Servo arm pulls pin through a short linear stroke
-- **Strong when locked**: C-loops transfer axial load through the pin in shear. Pin shear strength is well-understood and easy to calculate
-- **Symmetric**: Same C-hinge part printed multiple times. Same pin used everywhere
+- **Binary release**: Tongue in = locked, tongue out = open hook. No force balancing, no partial engagement, no "can one latch hold?" uncertainty. The geometry guarantees separation when a tongue is retracted
+- **Simple servo action**: Linear tongue retraction (sideways). Servo arm pulls the tongue out of the C-gap. No rotation, no twist, no complex linkage
+- **Passive C-hooks**: The C-hooks are just geometry on the body sections — no moving parts, no mechanism to jam. All the action is in the tongue, which is a simple sliding piece
+- **Strong when locked**: With tongue inserted, the C-hook + tongue form a closed structural loop. Axial loads transfer through the loop in compression/shear — well-understood load path
+- **Symmetric**: Same C-hook part printed multiple times. Same tongue design used everywhere
 - **Full axial separation**: Body sections push apart completely, standard parachute deployment geometry
-- **No tube cutout**: Joint is at the separation plane, no weakening of the body tube
+- **No tube cutout**: Latches are at the separation plane, no weakening of the body tube
 
 **Concerns:**
 
-- **Pin extraction force**: Pin must slide out cleanly under servo pull. Friction, corrosion, or deformation under load could impede extraction. Smooth pin surface, correct tolerances, and lubrication needed. Pin should not be under compression when loaded axially (C-loop geometry should transfer loads through shear, not clamping)
-- **C-loop strength**: The printed C-loops must handle flight loads without cracking or deforming. Wall thickness, infill, and print orientation critical. PC CF should have adequate strength, but needs analysis
-- **Pin retention during flight**: Pin must not slide out under vibration or G-loads. Options: friction fit, slight taper, detent notch, or servo holding the pin in place. The pin pull direction should be perpendicular to the primary load direction (axial) so flight loads don't tend to push the pin out
-- **Servo torque**: Must overcome pin friction + any detent. Linear pull via servo arm — calculate required force and arm geometry
-- **Tolerances**: C-loops must interlock cleanly. 3D printing tolerance for the loop gap and pin hole diameter. Print and test iterate
-- **Cold weather**: Pin friction and servo performance at -10 to -20°C
-- **Tethering**: After pin extraction, the pin itself must be tethered (to the servo arm or enclosure). Released C-loop halves separate with the body sections they're attached to — inherently tethered
+- **Tongue retraction force**: Tongue must slide out cleanly under servo pull. Under axial flight loads, the tongue may be loaded in compression or shear — friction between tongue and C-hook surfaces could resist retraction. Smooth surfaces, correct tolerances, and lubrication needed. The tongue geometry should be designed so axial loads do not clamp the tongue (loads should transfer through the C-hook walls, not through friction on the tongue)
+- **C-hook strength**: The printed C-hooks must handle flight loads without cracking or deforming. Wall thickness, infill, and print orientation critical. PC CF should have adequate strength, but needs analysis
+- **Tongue retention during flight**: Tongue must not slide out under vibration or G-loads. The servo holds the tongue in position, and the retraction direction should be perpendicular to the primary axial load so flight loads don't tend to push the tongue out. Additional options: friction fit, slight taper, or detent
+- **Servo torque**: Must overcome tongue friction + any detent force. Linear pull via servo arm — calculate required force and arm geometry
+- **Tolerances**: C-hook gap and tongue dimensions must match. 3D printing tolerance for the gap width and tongue thickness. Print and test iterate
+- **Cold weather**: Tongue friction and servo performance at -10 to -20°C
+- **Tethering**: After tongue retraction, the tongue remains attached to the servo arm (inherently tethered). C-hooks are fixed to their body sections (inherently tethered)
 
 #### Option B: Symmetric Dual-Half Bayonet (Alternative)
 
@@ -375,7 +388,7 @@ The bayonet joint is split into two identical halves, positioned 180° apart. Ea
 
 **Concerns:**
 
-- Lug geometry is the critical design parameter — must hold flight loads with two halves but release under spring force with one half. This is the key weakness vs. the C-hinge: the bayonet requires careful force-balancing between lug engagement depth and spring force, whereas the C-hinge release is binary (pin in/out)
+- Lug geometry is the critical design parameter — must hold flight loads with two halves but release under spring force with one half. This is the key weakness vs. the C-latch: the bayonet requires careful force-balancing between lug engagement depth and spring force, whereas the C-latch release is binary (tongue in/out)
 - Must not creep under vibration — needs detent or servo holding torque
 - Bayonet parts stay in the bay after release — potential tangle with parachute
 
@@ -388,9 +401,9 @@ Both options share:
 | **Identical halves** | Same part printed multiple times. One design, multiple prints |
 | **Spring deployment** | Preloaded springs push body sections apart after release |
 | **Wall-hugging servo enclosures** | Servo + battery in smooth 3D printed fairings against tube wall (see section 2.9) |
-| **4 servos total** | One per mechanism half, 2 per joint, 2 joints |
+| **4 servos total** | One per latch half, 2 per joint, 2 joints |
 | **Tethering** | All released parts remain attached to a rocket section |
-| **FC mapping** | FC #1 controls half A at both joints, FC #2 controls half B at both joints |
+| **FC mapping** | FC #1 controls latch #1 at both joints, FC #2 controls latch #2 at both joints |
 
 ### 4.4 Redundancy Analysis
 
@@ -398,27 +411,27 @@ Applies to both mechanism options:
 
 | Scenario | Result |
 |----------|--------|
-| Both FCs fire normally | Both halves release → clean separation |
-| FC #1 fires, FC #2 fails | Half A releases → separation (C-hinge: loops fall apart; bayonet: one half can't hold) |
-| FC #2 fires, FC #1 fails | Half B releases → separation (same logic) |
-| Both FCs fail | Both halves remain locked → no separation (ballistic) |
-| Servo #1 jams (mechanical) | FC #2 releases half B → separation |
-| Servo #2 jams (mechanical) | FC #1 releases half A → separation |
+| Both FCs fire normally | Both latches release → clean separation |
+| FC #1 fires, FC #2 fails | Latch #1 releases → separation (C-latch: open hook holds nothing; bayonet: one half can't hold) |
+| FC #2 fires, FC #1 fails | Latch #2 releases → separation (same logic) |
+| Both FCs fail | Both latches remain locked → no separation (ballistic) |
+| Servo #1 jams (mechanical) | FC #2 releases latch #2 → separation |
+| Servo #2 jams (mechanical) | FC #1 releases latch #1 → separation |
 
 True independent redundancy in both options: no single electrical or mechanical failure prevents recovery.
 
 ### 4.5 Mechanism Selection — TODO
 
-Decision criteria for selecting between Option A (C-hinge) and Option B (bayonet):
+Decision criteria for selecting between Option A (C-latch) and Option B (bayonet):
 
 1. **Prototype both** — print test versions of each, test fit and release on a body tube section
-2. **Release reliability** — C-hinge has binary release (pin in/out), bayonet requires force-balancing. This strongly favors Option A
-3. **Structural analysis** — compare load capacity of C-loops vs. bayonet lugs under flight loads
-4. **Pin extraction testing** — verify pin pulls cleanly under realistic conditions (load, cold, vibration)
+2. **Release reliability** — C-latch has binary release (tongue in/out), bayonet requires force-balancing. This strongly favors Option A
+3. **Structural analysis** — compare load capacity of C-hooks vs. bayonet lugs under flight loads
+4. **Tongue retraction testing** — verify tongue retracts cleanly under realistic conditions (load, cold, vibration)
 5. **TAP feedback** — discuss both with Rolf before committing
 6. **Ease of field assembly** — which is simpler to set up and verify at the launch site?
 
-Current preference: **Option A (C-hinge)** due to binary release guarantee.
+Current preference: **Option A (C-latch)** due to binary release guarantee.
 
 ### 4.6 Design Challenges — TODO
 
@@ -428,7 +441,7 @@ Regardless of which mechanism is selected:
 - **Spring force**: Must reliably push sections apart and deploy parachute at all expected altitudes. Validated by ground testing
 - **Servo selection**: Must reliably actuate in cold weather (Swedish winter, -10 to -20°C at altitude), under vibration, after sustaining boost G-loads. Torque margin needed
 - **Tolerances**: 3D printed parts have different tolerances than machined parts. Test under realistic conditions, print spares
-- **Tethering**: All released parts (pins, mechanism halves) must remain attached to a rocket section. No parts may descend without a recovery system (Tripoli non-certification condition)
+- **Tethering**: All parts must remain attached to a rocket section. Tongues are tethered to servo arms, C-hooks are fixed to body sections. No parts may descend without a recovery system (Tripoli non-certification condition)
 - **Wall-hugging enclosures**: Must not snag parachute or shock cord. Ground test with actual parachute packing
 - **Discuss with Rolf early**: Non-pyro separation is less common for L3. TAP approval of the concept is needed before detailed design
 
@@ -437,7 +450,7 @@ Regardless of which mechanism is selected:
 | Parameter | Value |
 |-----------|-------|
 | Trigger | Apogee detection (barometric) |
-| Mechanism | Servo-actuated release + spring separation (TBD: C-hinge or bayonet) |
+| Mechanism | Servo-actuated release + spring separation (TBD: C-latch or bayonet) |
 | Parachute | TBD size drogue |
 | Descent rate under drogue | TBD m/s |
 | Separation point | TBD |
@@ -447,7 +460,7 @@ Regardless of which mechanism is selected:
 | Parameter | Value |
 |-----------|-------|
 | Trigger | Altitude-based (TBD meters AGL) |
-| Mechanism | Servo-actuated release + spring separation (TBD: C-hinge or bayonet) |
+| Mechanism | Servo-actuated release + spring separation (TBD: C-latch or bayonet) |
 | Parachute | TBD size main |
 | Descent rate under main | TBD m/s (must not exceed 35 ft/s = 10.7 m/s per Tripoli rules) |
 | Separation point | TBD |
@@ -465,17 +478,17 @@ Regardless of which mechanism is selected:
 
 Per Tripoli L3 rules: *"Dual redundant electronics are required for all recovery events. Two completely independent and separate electronic recovery systems must be incorporated. Neither system must adversely affect the other. Redundancy means completely separate systems, including batteries, switches, avionics, and energetics."*
 
-With servo-actuated separation, "energetics" is replaced by servo + pin/mechanism + spring. Each system controls its own mechanism halves across both separation joints.
+With servo-actuated separation, "energetics" is replaced by servo + tongue/mechanism + spring. Each system controls its own C-latch at both separation joints.
 
 | Component | Primary System (FC #1) | Backup System (FC #2) |
 |-----------|----------------------|---------------------|
 | Flight computer | Custom FC (CATS Vega clone, improved) | CATS Vega (original) or second custom clone |
 | Battery | Dedicated battery #1 | Dedicated battery #2 |
 | Arming switch | Key switch #1 | Key switch #2 |
-| Drogue release | Servo #1 → lateral pin at C-hinge #1 (drogue joint) | Servo #2 → lateral pin at C-hinge #2 (drogue joint) |
-| Main release | Servo #3 → lateral pin at C-hinge #1 (main joint) | Servo #4 → lateral pin at C-hinge #2 (main joint) |
+| Drogue release | Servo #1 → retracts tongue at C-latch #1 (drogue joint) | Servo #2 → retracts tongue at C-latch #2 (drogue joint) |
+| Main release | Servo #3 → retracts tongue at C-latch #1 (main joint) | Servo #4 → retracts tongue at C-latch #2 (main joint) |
 
-The two systems share no electrical connections. Each has independent power, switching, sensing, and servo output. Each controls one of the two identical C-hinge pairs at each joint. Either system alone triggers separation.
+The two systems share no electrical connections. Each has independent power, switching, sensing, and servo output. Each controls one of the two C-latches at each joint. Either system alone triggers separation.
 
 ### 4.11 Motor Note
 
@@ -485,10 +498,11 @@ The M1350W-PS is a plugged motor — no motor ejection charge. All recovery depe
 
 The following approaches were evaluated earlier and set aside:
 
-- **Dual pin (without C-hinge)**: Two independent pins, each pulled by one servo. Simpler mechanically, but harder to ensure one pin alone cannot hold against springs while both together resist flight loads. The C-hinge solves this by making the release binary
+- **Dual pin (without C-latch)**: Two independent pins, each pulled by one servo. Simpler mechanically, but harder to ensure one pin alone cannot hold against springs while both together resist flight loads. The C-latch solves this by making the release binary
 - **Single bayonet with dual servos**: One bayonet ring, two servos rotating it in opposite directions. Cleaner single mechanism, but a jammed bayonet blocks both systems — not truly independent failure paths
 - **Hybrid (bayonet + pin bypass)**: Primary via bayonet rotation, backup via pin pull releasing entire bayonet assembly. True mechanical independence, but asymmetric design — two different part types, more complex, tether management concerns
-- **Hinged door**: Hatch in body tube wall with hinge pins on two sides. Pull either pin → door swings open → parachute deploys sideways. Mechanically elegant degraded mode, but the tube cutout weakens structural integrity, creates aerodynamic discontinuity, and requires sideways parachute deployment which is non-standard. The C-hinge achieves the same binary release guarantee while maintaining full axial separation and no tube cutout
+- **Hinged door**: Hatch in body tube wall with hinge pins on two sides. Pull either pin → door swings open → parachute deploys sideways. Mechanically elegant degraded mode, but the tube cutout weakens structural integrity, creates aerodynamic discontinuity, and requires sideways parachute deployment which is non-standard. The C-latch achieves the same binary release guarantee while maintaining full axial separation and no tube cutout
+- **Interlocking C-loops with lateral pin**: C-shaped loops on each body section interlock like a knuckle hinge, held together by a lateral pin through both loops. Pull pin to release. Evaluated but replaced by the simpler C-latch concept where C-hooks are passive receptacles and the tongue is the only moving part
 
 ---
 
@@ -502,11 +516,11 @@ The following approaches were evaluated earlier and set aside:
 
 *TODO: Create wiring diagram showing:*
 
-- Battery #1 → Key switch #1 → Primary FC → Servo #1 (drogue C-hinge #1 pin) + Servo #3 (main C-hinge #1 pin)
-- Battery #2 → Key switch #2 → Backup FC → Servo #2 (drogue C-hinge #2 pin) + Servo #4 (main C-hinge #2 pin)
+- Battery #1 → Key switch #1 → Primary FC → Servo #1 (drogue C-latch #1 tongue) + Servo #3 (main C-latch #1 tongue)
+- Battery #2 → Key switch #2 → Backup FC → Servo #2 (drogue C-latch #2 tongue) + Servo #4 (main C-latch #2 tongue)
 - Physical separation between systems
 - Servo connections (signal + power)
-- Mechanical linkage: servo arm → pin pull (conceptual)
+- Mechanical linkage: servo arm → tongue retraction (conceptual)
 
 ### 5.2 Primary System
 
@@ -514,8 +528,8 @@ The following approaches were evaluated earlier and set aside:
 |-----------|------|-----|
 | Power | Battery #1 (TBD V) | Key switch #1 |
 | Switched power | Key switch #1 | Primary FC power input |
-| Servo channel 1 | Primary FC drogue output | Servo #1 → pulls lateral pin at drogue C-hinge #1 |
-| Servo channel 2 | Primary FC main output | Servo #3 → pulls lateral pin at main C-hinge #1 |
+| Servo channel 1 | Primary FC drogue output | Servo #1 → retracts tongue at drogue C-latch #1 |
+| Servo channel 2 | Primary FC main output | Servo #3 → retracts tongue at main C-latch #1 |
 
 ### 5.3 Backup System
 
@@ -523,8 +537,8 @@ The following approaches were evaluated earlier and set aside:
 |-----------|------|-----|
 | Power | Battery #2 (TBD V) | Key switch #2 |
 | Switched power | Key switch #2 | Backup FC power input |
-| Servo channel 1 | Backup FC drogue output | Servo #2 → pulls lateral pin at drogue C-hinge #2 |
-| Servo channel 2 | Backup FC main output | Servo #4 → pulls lateral pin at main C-hinge #2 |
+| Servo channel 1 | Backup FC drogue output | Servo #2 → retracts tongue at drogue C-latch #2 |
+| Servo channel 2 | Backup FC main output | Servo #4 → retracts tongue at main C-latch #2 |
 
 ---
 
@@ -713,7 +727,7 @@ If flutter margin insufficient with PC CF alone:
 - [ ] Motor mount assembly
 - [ ] Centering ring installation
 - [ ] Body tube preparation
-- [ ] Separation mechanism prototype printing and testing (C-hinge and bayonet)
+- [ ] Separation mechanism prototype printing and testing (C-latch and bayonet)
 - [ ] Mechanism selection after prototyping
 - [ ] Final mechanism parts printing and fit testing
 - [ ] Wall-hugging servo enclosure printing and fit testing
@@ -727,7 +741,7 @@ If flutter margin insufficient with PC CF alone:
 - [ ] Weight and CG measurements
 - [ ] CP marking on airframe
 - [ ] Ground test of electronics (both systems independently)
-- [ ] Separation mechanism ground testing (each half independently)
+- [ ] Separation mechanism ground testing (each latch independently)
 
 ### 10.2 Construction Photos
 
@@ -764,7 +778,7 @@ Electronic deployment count: 1 of 2 minimum complete.
 - [ ] Igniter (FirstFire)
 - [ ] Batteries charged (2×, one per system)
 - [ ] Key switches and keys (2×)
-- [ ] Spare C-hinge halves, pins, and servos
+- [ ] Spare C-hooks, tongues, and servos
 - [ ] Tools for field assembly
 
 ### 12.2 At Launch Site — Before Assembly
@@ -783,11 +797,11 @@ Electronic deployment count: 1 of 2 minimum complete.
 - [ ] Pack drogue parachute
 - [ ] Pack main parachute
 - [ ] Preload separation springs
-- [ ] Engage C-hinge pairs and insert lateral pins at drogue joint
-- [ ] Engage C-hinge pairs and insert lateral pins at main joint
-- [ ] Verify pin engagement at both joints (visual + tactile check)
-- [ ] Verify all tethers attached (pins tethered to servo arms/enclosures)
-- [ ] Connect servo mechanisms to pins
+- [ ] Insert tongues into C-hooks at drogue joint (both C-latches)
+- [ ] Insert tongues into C-hooks at main joint (both C-latches)
+- [ ] Verify tongue engagement at both joints (visual + tactile check)
+- [ ] Verify all tethers attached (tongues tethered to servo arms)
+- [ ] Connect servo mechanisms to tongues
 - [ ] Connect primary FC wiring and servos (#1, #3)
 - [ ] Connect backup FC wiring and servos (#2, #4)
 - [ ] Arm primary system (key switch #1)
@@ -799,7 +813,7 @@ Electronic deployment count: 1 of 2 minimum complete.
 
 ### 12.4 Post-Flight
 
-- [ ] Recover rocket (all parts, including pins)
+- [ ] Recover rocket (all parts)
 - [ ] Present to TAP as recovered
 - [ ] TAP inspects for excessive damage
 - [ ] TAP determines certification result
@@ -816,15 +830,15 @@ Electronic deployment count: 1 of 2 minimum complete.
 |-------------|------------|-------------|
 | Motor CATO | Single-use motor, proper assembly | Non-certification |
 | Motor retention failure | Adequate retention hardware, inspection | Non-certification |
-| Primary electronics failure | Backup system pulls pin at C-hinge #2 → separation | Successful recovery |
-| Backup electronics failure | Primary system pulls pin at C-hinge #1 → separation | Successful recovery |
+| Primary electronics failure | Backup system retracts tongue at C-latch #2 → separation | Successful recovery |
+| Backup electronics failure | Primary system retracts tongue at C-latch #1 → separation | Successful recovery |
 | Both electronics fail | Design for reliability, ground test | Non-certification (ballistic descent) |
-| Single servo failure | Other system's servo pulls its pin → separation | Successful recovery |
+| Single servo failure | Other system's servo retracts its tongue → separation | Successful recovery |
 | Both servos fail on same joint | Ground testing, servo selection, cold testing | Failed separation |
-| Pin stuck (friction/deformation) | Smooth pin surface, lubrication, tolerances, cold testing; other pin still releases | Successful recovery (degraded) |
-| C-loop cracked/broken | PC CF strength analysis, print orientation, infill, test loads | Structural failure at joint |
+| Tongue stuck (friction/binding) | Smooth surfaces, lubrication, tolerances, cold testing; other tongue still retracts | Successful recovery (degraded) |
+| C-hook cracked/broken | PC CF strength analysis, print orientation, infill, test loads | Structural failure at joint |
 | Spring insufficient | Ground testing at various temperatures, margin in spring force | Incomplete separation |
-| Premature pin extraction (vibration/G) | Pin pull direction perpendicular to axial loads, detent, servo holding | Premature separation during boost |
+| Premature tongue retraction (vibration/G) | Servo holds tongue in position, retraction direction perpendicular to axial loads, detent | Premature separation during boost |
 | Tether tangle with parachute | Tether routing, length management, ground test | Tangled recovery |
 | Parachute snags on servo enclosure | Wall-hugging smooth fairing, ground test with actual packing | Failed deployment |
 | Fin flutter | Flutter analysis, carbon reinforcement, progressive test flights | Structural failure |
@@ -835,17 +849,17 @@ Electronic deployment count: 1 of 2 minimum complete.
 
 | Test | Purpose | When |
 |------|---------|------|
-| C-hinge prototype | Print and test C-loop engagement, pin insertion/extraction | Early prototyping |
+| C-latch prototype | Print and test C-hook + tongue engagement and release | Early prototyping |
 | Bayonet prototype | Print and test bayonet half engagement/release | Early prototyping |
 | Mechanism selection | Compare prototypes, select winner | After prototyping |
-| Pin extraction force measurement | Quantify force needed to pull pin under load and no-load | After mechanism selection |
+| Tongue retraction force measurement | Quantify force needed to retract tongue under load and no-load | After mechanism selection |
 | Servo enclosure fit test | Verify parachute slides past without snagging | During construction |
-| Separation bench test (both pins) | Verify spring separates when both pins pulled | During construction |
-| Redundancy test (pin #1 only) | Verify pulling pin #1 alone causes separation | During construction |
-| Redundancy test (pin #2 only) | Verify pulling pin #2 alone causes separation | During construction |
+| Separation bench test (both tongues) | Verify spring separates when both tongues retracted | During construction |
+| Redundancy test (tongue #1 only) | Verify retracting tongue #1 alone causes separation | During construction |
+| Redundancy test (tongue #2 only) | Verify retracting tongue #2 alone causes separation | During construction |
 | Cold temperature test | Verify servo and mechanism operation at -10 to -20°C | During construction |
-| Vibration/shake test | Verify pins don't extract under simulated flight loads | During construction |
-| Tether deployment test | Verify tethered pins/parts don't tangle with parachute | During construction |
+| Vibration/shake test | Verify tongues don't retract under simulated flight loads | During construction |
+| Tether deployment test | Verify tethered tongues don't tangle with parachute | During construction |
 | Flight #2 (J420R) | Validate airframe, electronics, separation mechanism in flight | Before L flight |
 | Flight #3 (L1000W) | Stress test at higher loads and speeds | Before M flight |
 | Electronics ground test | Verify both systems detect apogee/altitude correctly | Before each flight |
@@ -858,8 +872,8 @@ Electronic deployment count: 1 of 2 minimum complete.
 | FAR 101.25 | Altitude prediction within waiver |
 | Waiver radius | Wind simulation, dual deploy for tight landing |
 | Landing velocity ≤ 35 ft/s | Parachute sizing calculation |
-| Dual redundant electronics | Two independent systems, each controlling one C-hinge pin |
-| No untethered components | All pins and mechanism parts tethered to rocket sections |
+| Dual redundant electronics | Two independent systems, each controlling one C-latch tongue |
+| No untethered components | Tongues tethered to servo arms, C-hooks fixed to body sections |
 | CP marked on rocket | External marking |
 
 ---
@@ -872,7 +886,7 @@ Electronic deployment count: 1 of 2 minimum complete.
 
 ### B. OpenSCAD Design Files
 
-*TODO: Include .scad source for fin can, fins, C-hinge halves, and servo enclosures*
+*TODO: Include .scad source for fin can, fins, C-hooks, tongues, and servo enclosures*
 
 ### C. Thrust Curve Data
 
@@ -890,19 +904,19 @@ Electronic deployment count: 1 of 2 minimum complete.
 
 *TODO: Detailed drawings of selected separation mechanism, including:*
 
-- C-hinge loop geometry (OpenSCAD parametric design)
-- Lateral pin dimensions and material (shear strength analysis)
-- Pin extraction force analysis (friction, detent, servo torque margin)
+- C-hook geometry (OpenSCAD parametric design)
+- Tongue dimensions and material
+- Tongue retraction force analysis (friction, detent, servo torque margin)
 - Spring selection and force calculations
-- Servo selection and arm geometry for linear pin pull
-- Anti-vibration pin retention design
+- Servo selection and arm geometry for linear tongue retraction
+- Anti-vibration tongue retention design (servo holding + optional detent)
 - Wall-hugging servo enclosure design
-- Redundancy verification test results (each pin independently)
-- Tether routing plan (pins tethered to servo arms)
+- Redundancy verification test results (each tongue independently)
+- Tether routing plan (tongues tethered to servo arms)
 - Assembly and preload procedure
 - Print settings and tolerance measurements
 - Cold weather test results
-- Prototype comparison results (C-hinge vs. bayonet)
+- Prototype comparison results (C-latch vs. bayonet)
 
 ### G. Forms
 

--- a/docs/certification/l3-design-document.md
+++ b/docs/certification/l3-design-document.md
@@ -44,7 +44,7 @@ Tripoli Level 3 high-power certification using a scratch-built rocket with a sin
 | Dry weight (no motor) | TBD |
 | Liftoff weight (with motor) | TBD |
 | Motor | AeroTech M1350W-PS (75mm, 5178 N-s) |
-| Recovery | Dual deploy, dual redundant electronics, servo-actuated spring release |
+| Recovery | Dual deploy, dual redundant electronics, dual-half bayonet spring release |
 | Expected altitude | TBD |
 | Number of fins | TBD |
 | Fin material | Spectrum PC CF (3D printed polycarbonate + carbon fiber) |
@@ -55,7 +55,7 @@ Tripoli Level 3 high-power certification using a scratch-built rocket with a sin
 - Progressive flight testing on J and L motors before cert flight
 - 3D printed fin can in PC CF with carbon rod reinforcement for flutter resistance
 - Dual redundant electronics as required by Tripoli L3 rules
-- Servo-actuated spring release instead of black powder ejection charges
+- Symmetric dual-half bayonet spring release — one design, two identical halves, true independent redundancy
 - Single-use motor to avoid reloadable hardware risk
 
 ---
@@ -199,11 +199,10 @@ For pre-certification test flights:
 |------|--------------|----------|--------|
 | Drogue parachute | TBD size | 1 | TBD |
 | Main parachute | TBD size | 1 | TBD |
-| Nomex chute protectors | TBD | 2 | TBD |
-| Separation springs | TBD | TBD | TBD |
-| Separation mechanism hardware | TBD (pins/bayonet/hybrid) | TBD | TBD |
-| Servos (separation) | TBD | TBD | TBD |
-| Tether cord (mechanism retention) | TBD | TBD | TBD |
+| Separation springs | TBD | TBD per joint | TBD |
+| Bayonet half (printed) | Spectrum PC CF, identical part | 2 per joint (4 total for dual deploy) | Printed by candidate |
+| Servos (separation) | TBD | 1 per bayonet half (4 total) | TBD |
+| Tether cord (mechanism retention) | TBD | As needed | TBD |
 
 ### 3.3 Electronics
 
@@ -215,8 +214,6 @@ For pre-certification test flights:
 | Battery (backup) | TBD | 1 | TBD |
 | Key switch (primary) | TBD | 1 | TBD |
 | Key switch (backup) | TBD | 1 | TBD |
-| Servos (drogue separation) | TBD | TBD per system | TBD |
-| Servos (main separation) | TBD | TBD per system | TBD |
 
 ### 3.4 Motor
 
@@ -232,21 +229,21 @@ For pre-certification test flights:
 
 ### 4.1 Recovery Architecture
 
-Dual deployment using servo-actuated spring release mechanisms, controlled by dual redundant electronics:
+Dual deployment using symmetric dual-half bayonet release mechanisms with spring separation, controlled by dual redundant electronics:
 
 | Event | Altitude | Device | Action |
 |-------|----------|--------|--------|
-| Apogee | Apogee detection | Primary FC + Backup FC | Servo releases mechanism → spring separates body → drogue deploys |
-| Main | TBD (e.g., 300m AGL) | Primary FC + Backup FC | Servo releases mechanism → spring separates body → main deploys |
+| Apogee | Apogee detection | Primary FC + Backup FC | Either servo releases its bayonet half → spring separates body → drogue deploys |
+| Main | TBD (e.g., 300m AGL) | Primary FC + Backup FC | Either servo releases its bayonet half → spring separates body → main deploys |
 
 ### 4.2 Separation Mechanism Concept
 
 Instead of black powder ejection charges, separation is achieved mechanically:
 
 1. **Springs** are preloaded between body sections during assembly, providing separation force
-2. **Retention mechanism** holds the sections together against the spring preload during flight
-3. **Servos** actuate the release mechanism on command from the flight computer
-4. Once released, springs push the sections apart and deploy the parachute
+2. **Dual-half bayonet** holds the sections together against the spring preload during flight
+3. **Servos** release the bayonet halves on command from the flight computer
+4. Once either half is released, the remaining half cannot hold against the spring force alone, and the sections separate
 
 **Advantages over BP charges**:
 
@@ -255,52 +252,86 @@ Instead of black powder ejection charges, separation is achieved mechanically:
 - No hot gas near parachutes — no Nomex protectors needed
 - Clean separation — no soot, no pressure spike
 
-### 4.3 Separation Mechanism Candidates
+### 4.3 Selected Mechanism: Symmetric Dual-Half Bayonet
 
-The central design challenge is Tripoli's redundancy requirement: each FC must independently be able to trigger separation, while the mechanism must reliably hold during boost loads. Several candidate approaches are under consideration.
+The bayonet joint is split into two identical halves, positioned 180° apart. Each half is an independent latch controlled by its own servo and FC system.
 
-#### Option A: Dual Pin
+#### Operating Principle
 
-Two independent pins per separation joint, each controlled by one servo (one per FC system). Each pin carries part of the flight loads.
+```
+    LOCKED STATE                    EITHER HALF RELEASED
+    ┌──────────┐                    ┌──────────┐
+    │  Body A  │                    │  Body A  │
+    ├──┐    ┌──┤                    ├──┐       │
+    │H1│    │H2│  ← both halves    │H1│       │  ← half 2 released
+    ├──┘    └──┤    engaged         ├──┘       │    by servo #2
+    │  Body B  │                    │  Body B  │ ←── springs push apart
+    └──────────┘                    └──────────┘
+```
 
-- **Release**: Either pin removal alone allows springs to push sections apart (pin geometry and spring force designed so one pin cannot hold against springs)
-- **Retention during flight**: Both pins together handle full aerodynamic and thrust loads
-- **Independence**: Each servo controls its own pin — no mechanical interaction
-- **Concern**: If one pin alone must NOT hold against the springs, each pin is only carrying partial load. Need to verify that vibration or G-forces cannot cause a single pin to slip. Careful geometry needed — tapered pins, detent depth, etc.
+- **Locked**: Both bayonet halves (H1, H2) engaged. Together they carry full flight loads (axial thrust, drag, bending)
+- **Released**: Either servo releases its half. One half alone cannot resist the spring preload → sections separate
+- Each half is designed to carry approximately 50% of the axial load when both are engaged, but is deliberately unable to resist the full spring force alone
 
-#### Option B: Bayonet
+#### Key Design Properties
 
-A bayonet-style rotary latch between body sections. Two servos are mounted on opposite sides, each capable of rotating the bayonet to the release position.
+| Property | Value |
+|----------|-------|
+| Number of halves per joint | 2 (identical parts) |
+| Halves per separation event | 2 (drogue joint + main joint) |
+| Total bayonet halves | 4 (2 joints × 2 halves) |
+| Servos total | 4 (one per half) |
+| Parts to design | **1** (same part used everywhere) |
+| FC #1 controls | Half A at drogue joint + Half A at main joint |
+| FC #2 controls | Half B at drogue joint + Half B at main joint |
 
-- **Release**: Either servo rotates the bayonet to unlock position — both rotate in opposing directions so they don't fight each other
-- **Retention during flight**: Bayonet lugs carry full axial and bending loads in the locked position
-- **Independence**: Two servos acting on the same bayonet ring via opposing rotational inputs. Either one alone can unlock
-- **Advantages**: Strong retention in locked state (bayonet lugs are load-bearing surfaces), clean single-mechanism design, well-understood locking geometry
-- **Concerns**: Bayonet must rotate freely under all conditions (cold, vibration, slight misalignment). Binding under load is the main failure mode. Tolerances critical. Must not rotate under vibration alone — needs a detent or friction hold in the locked position that either servo can overcome
+#### Redundancy Analysis
 
-#### Option C: Hybrid (Bayonet + Pin Bypass)
+| Scenario | Result |
+|----------|--------|
+| Both FCs fire normally | Both halves release simultaneously → clean separation |
+| FC #1 fires, FC #2 fails | Half A releases → half B alone cannot hold → separation |
+| FC #2 fires, FC #1 fails | Half B releases → half A alone cannot hold → separation |
+| Both FCs fail | Both halves remain locked → no separation (ballistic) |
+| Servo #1 jams (mechanical) | FC #2 releases half B → half A alone cannot hold → separation |
+| Servo #2 jams (mechanical) | FC #1 releases half A → half B alone cannot hold → separation |
 
-Primary separation via bayonet (servo #1 rotates to unlock). Independent backup via pin pull (servo #2 pulls a pin that releases the entire bayonet mechanism from the body).
+True independent redundancy: no single electrical or mechanical failure prevents separation.
 
-- **Primary path (System 1)**: Servo rotates bayonet to unlock → springs separate
-- **Backup path (System 2)**: Servo pulls pin → bayonet assembly detaches from one body section entirely → springs separate. The released bayonet mechanism stays attached via tether cord to avoid separate falling parts
-- **Independence**: Two completely different mechanical paths to the same result. No shared failure modes between rotary and linear release
-- **Advantages**: True mechanical independence — a jammed bayonet doesn't prevent pin-pull separation. The pin bypass is a simple, robust backup
-- **Concerns**: More complex mechanism, more parts. Tether management (bayonet assembly must not tangle with parachute). Pin must hold under flight loads but release cleanly when pulled. Need to ensure the pin-pull path provides enough clearance for springs to push sections apart even with bayonet still partially engaged
+#### Manufacturing Advantage
 
-#### Tethering
+One OpenSCAD design, one STL/3MF, print multiples. All four bayonet halves (2 per joint) are the same part. Spares are trivial — bring extras to the launch.
 
-All separation mechanism hardware (pins, bayonet assemblies, servos) must remain attached to a rocket section via tether cords. No parts may descend without a recovery system — this is a Tripoli non-certification condition ("components which descend without a recovery system").
+#### Design Challenges — TODO
+
+- **Lug geometry**: Each half carries ~50% of flight loads when locked. Lug shape must be strong enough for this but unable to resist spring force alone. This is the critical design parameter — lug engagement depth and spring force must be carefully matched
+- **Rotational vs. linear release**: Decide whether the servo rotates the half (traditional bayonet twist) or pulls it linearly (slide out). Rotation may be simpler for a 3D printed part; linear pull may be more reliable with a servo arm
+- **Anti-vibration**: Each half must not creep toward release under motor vibration. Options: detent, friction fit, slight interference, servo holding torque
+- **Spring sizing**: Springs must overcome friction of one remaining half plus parachute packing resistance. Must separate reliably at all altitudes. Ground test required
+- **Servo torque/force**: Must overcome detent + friction to release the half. Must not back-drive under vibration. Servo selection and torque analysis needed
+- **Tolerances**: 3D printed parts — test fit, iterate. Print several and measure variation
+- **Cold weather**: Verify mechanism operation at expected Swedish winter temperatures (-10 to -20°C at altitude). PC CF should be fine, but servo grease and spring rate may change
+- **Discuss with Rolf**: Get TAP approval of non-pyro separation concept before detailed design
+
+#### Considered Alternatives
+
+The following approaches were evaluated before selecting the symmetric dual-half bayonet:
+
+- **Dual pin**: Two independent pins, each pulled by one servo. Simpler mechanically, but harder to ensure one pin alone cannot hold against springs while both together resist flight loads. Pin geometry is fussy.
+- **Single bayonet with dual servos**: One bayonet ring, two servos rotating it in opposite directions. Cleaner single mechanism, but a jammed bayonet blocks both systems — not truly independent failure paths.
+- **Hybrid (bayonet + pin bypass)**: Primary via bayonet rotation, backup via pin pull releasing entire bayonet assembly. True mechanical independence, but more complex, more parts, tether management concerns.
+
+The symmetric dual-half bayonet was selected because it combines true independent redundancy with manufacturing simplicity — one part printed multiple times.
 
 ### 4.4 Design Challenges — TODO
 
-Regardless of which mechanism is selected:
+General challenges regardless of mechanism specifics:
 
-- **Redundancy logic**: Must satisfy Tripoli requirement that each system independently triggers recovery, without creating a mechanism that is too easy to release accidentally
-- **Structural analysis**: Retention mechanism must handle boost loads (axial: motor thrust + drag, bending: wind loads, vibration: motor resonance). Analysis needed for the selected mechanism
+- **Structural analysis**: Combined halves must handle boost loads (axial: motor thrust + drag, bending: wind loads, vibration: motor resonance)
 - **Spring force**: Must reliably push sections apart and deploy parachute at all expected altitudes. Validated by ground testing
 - **Servo selection**: Must reliably actuate in cold weather (Swedish winter), under vibration, after sustaining boost G-loads. Torque margin needed
-- **Tolerances**: 3D printed mechanism parts have different tolerances than machined parts. If mechanism is printed, test under realistic conditions
+- **Tolerances**: 3D printed mechanism parts have different tolerances than machined parts. Test under realistic conditions, print spares
+- **Tethering**: All released mechanism parts (bayonet halves, servos) must remain attached to a rocket section via tether. No parts may descend without a recovery system (Tripoli non-certification condition)
 - **Discuss with Rolf early**: Non-pyro separation is less common for L3. TAP approval of the concept is needed before detailed design
 
 ### 4.5 Drogue Deployment
@@ -308,7 +339,7 @@ Regardless of which mechanism is selected:
 | Parameter | Value |
 |-----------|-------|
 | Trigger | Apogee detection (barometric) |
-| Mechanism | Servo-actuated release + spring separation |
+| Mechanism | Dual-half bayonet release + spring separation |
 | Parachute | TBD size drogue |
 | Descent rate under drogue | TBD m/s |
 | Separation point | TBD |
@@ -318,7 +349,7 @@ Regardless of which mechanism is selected:
 | Parameter | Value |
 |-----------|-------|
 | Trigger | Altitude-based (TBD meters AGL) |
-| Mechanism | Servo-actuated release + spring separation |
+| Mechanism | Dual-half bayonet release + spring separation |
 | Parachute | TBD size main |
 | Descent rate under main | TBD m/s (must not exceed 35 ft/s = 10.7 m/s per Tripoli rules) |
 | Separation point | TBD |
@@ -336,17 +367,17 @@ Regardless of which mechanism is selected:
 
 Per Tripoli L3 rules: *"Dual redundant electronics are required for all recovery events. Two completely independent and separate electronic recovery systems must be incorporated. Neither system must adversely affect the other. Redundancy means completely separate systems, including batteries, switches, avionics, and energetics."*
 
-Note: "energetics" in the Tripoli rules refers to ejection charges. With servo-actuated separation, the equivalent is the servo + mechanism + spring system. Each system must independently be capable of triggering separation.
+With the dual-half bayonet, "energetics" is replaced by servo + bayonet half + spring. Each system controls its own bayonet halves across both separation joints.
 
-| Component | Primary System | Backup System |
-|-----------|---------------|---------------|
+| Component | Primary System (FC #1) | Backup System (FC #2) |
+|-----------|----------------------|---------------------|
 | Flight computer | Custom FC (CATS Vega clone, improved) | CATS Vega (original) or second custom clone |
 | Battery | Dedicated battery #1 | Dedicated battery #2 |
 | Arming switch | Key switch #1 | Key switch #2 |
-| Drogue release | Servo #1 → mechanism path A | Servo #2 → mechanism path B |
-| Main release | Servo #3 → mechanism path A | Servo #4 → mechanism path B |
+| Drogue release | Servo #1 → bayonet half A (drogue joint) | Servo #2 → bayonet half B (drogue joint) |
+| Main release | Servo #3 → bayonet half A (main joint) | Servo #4 → bayonet half B (main joint) |
 
-The two systems share no electrical connections. Each has independent power, switching, sensing, and servo output. The mechanical release paths are designed so either system alone can trigger separation (see section 4.3 for mechanism options).
+The two systems share no electrical connections. Each has independent power, switching, sensing, and servo output. Each controls one of the two identical bayonet halves at each joint. Either system alone triggers separation.
 
 ### 4.9 Motor Note
 
@@ -364,11 +395,11 @@ The M1350W-PS is a plugged motor — no motor ejection charge. All recovery depe
 
 *TODO: Create wiring diagram showing:*
 
-- Battery #1 → Key switch #1 → Primary FC → Drogue servo #1 + Main servo #1
-- Battery #2 → Key switch #2 → Backup FC → Drogue servo #2 + Main servo #2
+- Battery #1 → Key switch #1 → Primary FC → Servo #1 (drogue half A) + Servo #3 (main half A)
+- Battery #2 → Key switch #2 → Backup FC → Servo #2 (drogue half B) + Servo #4 (main half B)
 - Physical separation between systems
 - Servo connections (signal + power)
-- Mechanical linkage to release mechanism (conceptual)
+- Mechanical linkage to bayonet halves (conceptual)
 
 ### 5.2 Primary System
 
@@ -376,8 +407,8 @@ The M1350W-PS is a plugged motor — no motor ejection charge. All recovery depe
 |-----------|------|-----|
 | Power | Battery #1 (TBD V) | Key switch #1 |
 | Switched power | Key switch #1 | Primary FC power input |
-| Servo channel 1 | Primary FC drogue output | Servo #1 → drogue release path A |
-| Servo channel 2 | Primary FC main output | Servo #3 → main release path A |
+| Servo channel 1 | Primary FC drogue output | Servo #1 → drogue joint bayonet half A |
+| Servo channel 2 | Primary FC main output | Servo #3 → main joint bayonet half A |
 
 ### 5.3 Backup System
 
@@ -385,8 +416,8 @@ The M1350W-PS is a plugged motor — no motor ejection charge. All recovery depe
 |-----------|------|-----|
 | Power | Battery #2 (TBD V) | Key switch #2 |
 | Switched power | Key switch #2 | Backup FC power input |
-| Servo channel 1 | Backup FC drogue output | Servo #2 → drogue release path B |
-| Servo channel 2 | Backup FC main output | Servo #4 → main release path B |
+| Servo channel 1 | Backup FC drogue output | Servo #2 → drogue joint bayonet half B |
+| Servo channel 2 | Backup FC main output | Servo #4 → main joint bayonet half B |
 
 ---
 
@@ -575,18 +606,19 @@ If flutter margin insufficient with PC CF alone:
 - [ ] Motor mount assembly
 - [ ] Centering ring installation
 - [ ] Body tube preparation
-- [ ] Separation mechanism fabrication and testing
+- [ ] Bayonet half printing and fit testing
+- [ ] Separation mechanism assembly and bench testing
 - [ ] Electronics bay / nose cone electronics construction
 - [ ] Dual flight computer installation and wiring
-- [ ] Servo mechanism installation and testing
+- [ ] Servo installation and testing
 - [ ] Recovery harness assembly
 - [ ] Parachute packing
-- [ ] Spring preload and retention mechanism testing
+- [ ] Spring preload and bayonet engagement testing
 - [ ] Final assembly
 - [ ] Weight and CG measurements
 - [ ] CP marking on airframe
 - [ ] Ground test of electronics (both systems independently)
-- [ ] Separation mechanism ground testing (both systems independently)
+- [ ] Separation mechanism ground testing (each half independently)
 
 ### 10.2 Construction Photos
 
@@ -623,7 +655,7 @@ Electronic deployment count: 1 of 2 minimum complete.
 - [ ] Igniter (FirstFire)
 - [ ] Batteries charged (2×, one per system)
 - [ ] Key switches and keys (2×)
-- [ ] Spare servos
+- [ ] Spare bayonet halves and servos
 - [ ] Tools for field assembly
 
 ### 12.2 At Launch Site — Before Assembly
@@ -642,12 +674,13 @@ Electronic deployment count: 1 of 2 minimum complete.
 - [ ] Pack drogue parachute
 - [ ] Pack main parachute
 - [ ] Preload separation springs
-- [ ] Engage retention mechanism (pins/bayonet)
-- [ ] Verify mechanism engagement
-- [ ] Verify tethers attached
-- [ ] Connect servo mechanisms
-- [ ] Connect primary FC wiring and servos
-- [ ] Connect backup FC wiring and servos
+- [ ] Engage both bayonet halves at drogue joint
+- [ ] Engage both bayonet halves at main joint
+- [ ] Verify bayonet engagement at both joints
+- [ ] Verify all tethers attached
+- [ ] Connect servo mechanisms to bayonet halves
+- [ ] Connect primary FC wiring and servos (#1, #3)
+- [ ] Connect backup FC wiring and servos (#2, #4)
 - [ ] Arm primary system (key switch #1)
 - [ ] Verify primary FC status (LED/beep)
 - [ ] Arm backup system (key switch #2)
@@ -674,14 +707,14 @@ Electronic deployment count: 1 of 2 minimum complete.
 |-------------|------------|-------------|
 | Motor CATO | Single-use motor, proper assembly | Non-certification |
 | Motor retention failure | Adequate retention hardware, inspection | Non-certification |
-| Primary electronics failure | Backup system actuates servos via independent path | Successful recovery |
-| Backup electronics failure | Primary system actuates servos via independent path | Successful recovery |
+| Primary electronics failure | Backup system releases half B → separation | Successful recovery |
+| Backup electronics failure | Primary system releases half A → separation | Successful recovery |
 | Both electronics fail | Design for reliability, ground test | Non-certification (ballistic descent) |
-| Servo failure (single) | Redundant servo on other system releases via independent mechanical path | Successful recovery |
-| Servo failure (both on same joint) | Ground testing, servo selection, cold testing | Failed separation |
-| Mechanism jammed (bayonet binding / pin stuck) | Tolerances, lubrication, vibration testing; hybrid option provides alternate path | Failed separation |
+| Single servo failure | Other system's servo releases its half → one half cannot hold alone → separation | Successful recovery |
+| Both servos fail on same joint | Ground testing, servo selection, cold testing | Failed separation |
+| Bayonet half jammed | Tolerances, lubrication, vibration testing, print spares, test fit | Failed separation (mitigated: other half release still causes separation) |
 | Spring insufficient | Ground testing at various temperatures, margin in spring force | Incomplete separation |
-| Premature release (vibration/G) | Structural analysis, detent design, locking geometry | Drag separation during boost |
+| Premature bayonet release (vibration/G) | Detent design, lug geometry, servo holding torque, vibration testing | Drag separation during boost |
 | Tether tangle with parachute | Tether routing, length management, ground test | Tangled recovery |
 | Fin flutter | Flutter analysis, carbon reinforcement, progressive test flights | Structural failure |
 | Unstable flight | Stability analysis, CP/CG verification, OpenRocket sim | Unsafe flight |
@@ -691,12 +724,13 @@ Electronic deployment count: 1 of 2 minimum complete.
 
 | Test | Purpose | When |
 |------|---------|------|
-| Separation mechanism bench test | Verify servo releases mechanism, spring separates sections | During construction |
-| Redundancy test (path A only) | Verify primary system alone triggers separation | During construction |
-| Redundancy test (path B only) | Verify backup system alone triggers separation | During construction |
-| Cold temperature test | Verify servo and mechanism operation at expected launch temps | During construction |
-| Vibration/shake test | Verify mechanism doesn't release under simulated flight loads | During construction |
-| Tether deployment test | Verify mechanism hardware doesn't tangle with parachute | During construction |
+| Bayonet half fit test | Verify printed parts engage/release cleanly | After printing |
+| Separation bench test (both halves) | Verify spring separates when both released | During construction |
+| Redundancy test (half A only) | Verify releasing half A alone causes separation | During construction |
+| Redundancy test (half B only) | Verify releasing half B alone causes separation | During construction |
+| Cold temperature test | Verify servo and mechanism operation at -10 to -20°C | During construction |
+| Vibration/shake test | Verify bayonet halves don't disengage under simulated flight loads | During construction |
+| Tether deployment test | Verify tethered parts don't tangle with parachute | During construction |
 | Flight #2 (J420R) | Validate airframe, electronics, separation mechanism in flight | Before L flight |
 | Flight #3 (L1000W) | Stress test at higher loads and speeds | Before M flight |
 | Electronics ground test | Verify both systems detect apogee/altitude correctly | Before each flight |
@@ -709,7 +743,7 @@ Electronic deployment count: 1 of 2 minimum complete.
 | FAR 101.25 | Altitude prediction within waiver |
 | Waiver radius | Wind simulation, dual deploy for tight landing |
 | Landing velocity ≤ 35 ft/s | Parachute sizing calculation |
-| Dual redundant electronics | Two independent systems with independent mechanical release paths |
+| Dual redundant electronics | Two independent systems, each controlling one bayonet half |
 | No untethered components | All mechanism parts tethered to rocket sections |
 | CP marked on rocket | External marking |
 
@@ -723,7 +757,7 @@ Electronic deployment count: 1 of 2 minimum complete.
 
 ### B. OpenSCAD Design Files
 
-*TODO: Include .scad source for fin can and fins*
+*TODO: Include .scad source for fin can, fins, and bayonet half*
 
 ### C. Thrust Curve Data
 
@@ -739,17 +773,18 @@ Electronic deployment count: 1 of 2 minimum complete.
 
 ### F. Separation Mechanism Design
 
-*TODO: Detailed drawings of selected separation mechanism, including:*
+*TODO: Detailed drawings of dual-half bayonet mechanism, including:*
 
-- Mechanism selection rationale (Option A/B/C from section 4.3)
-- Detailed drawings with dimensions
-- Structural analysis of retention under flight loads
-- Spring selection and force calculations
+- Bayonet half geometry (OpenSCAD parametric design)
+- Lug engagement depth and load analysis
+- Spring selection and force calculations (must overcome single-half friction)
 - Servo selection and torque requirements
-- Redundancy verification (both paths independently tested)
+- Anti-vibration detent design
+- Redundancy verification test results (each half independently)
 - Tether routing plan
 - Assembly and preload procedure
-- 3D printing considerations (if mechanism is printed)
+- Print settings and tolerance measurements
+- Cold weather test results
 
 ### G. Forms
 

--- a/docs/certification/l3-planning.md
+++ b/docs/certification/l3-planning.md
@@ -32,7 +32,7 @@ Incremental approach: build the L3 airframe early, fly it on progressively large
 | 1 | AeroTech J350 | 38mm | — | Peregrine | L2 certification | ✓ CATS Vega | ✅ Done |
 | 2 | AeroTech J420R | 38mm | 75→38mm | L3 airframe | Test new airframe, electronic deploy #2 | ✓ Custom FC | Planned |
 | 3 | AeroTech L1000W | 54mm | 75→54mm | L3 airframe | Stress test at higher impulse, electronic deploy #3 | ✓ Custom FC | Planned |
-| 4 | TBD M-class | 75mm | None | L3 airframe | **L3 certification flight** | ✓ Custom FC | Planned |
+| 4 | AeroTech M1350W-PS | 75mm | None | L3 airframe | **L3 certification flight** | ✓ Custom FC | Planned |
 
 ### Flight #2: J420R in L3 Airframe
 
@@ -60,6 +60,33 @@ Thrust-to-weight: 1000N average, 5:1 minimum → max liftoff mass 20.4 kg. Very 
 
 This flight validates the airframe under significantly higher loads and speeds before committing to the M-class cert flight.
 
+### Flight #4: M1350W-PS Certification
+
+The AeroTech M1350W-PS is the selected M-class motor for the L3 certification flight:
+
+| Parameter | Value |
+|-----------|-------|
+| Designation | M1350W |
+| Diameter | 75mm (native — no adapter) |
+| Length | 622mm |
+| Total impulse | 5178 N-s (1% into M-class) |
+| Average thrust | 1357 N |
+| Max thrust | 1766 N |
+| Burn time | 3.8 s |
+| Total weight | 4808 g |
+| Propellant | White Lightning |
+| Type | Single-use DMS |
+| Delay | **Plugged + Smoke** (no ejection charge) |
+
+Thrust-to-weight: 1357N average, 5:1 minimum → max liftoff mass 27.7 kg. Very generous margin.
+
+**Important notes**:
+
+- "-PS" = Plugged + Smoke. No motor ejection charge — electronic deployment is the **only** recovery mechanism. No motor backup unlike L2 flight. This makes flight computer reliability critical.
+- Requires L3 certification to purchase. Must be sourced through TAP members or prefect for the certification attempt.
+- Barely into M-class (5178 N-s vs 5120 N-s M threshold) — keeps velocities and forces as low as possible while meeting the requirement.
+- Built-in 3/8-16 threaded aluminum bulkhead for eye bolt attachment.
+
 ### Motor Adapter Strategy
 
 The 75mm motor mount is the native size for the L3 cert flight. Smaller motors require centering adapters:
@@ -68,19 +95,11 @@ The 75mm motor mount is the native size for the L3 cert flight. Smaller motors r
 |---------|-----------|---------|
 | 75mm → 38mm | J420R and other 38mm J motors | Flight #2 |
 | 75mm → 54mm | L1000W and other 54mm L motors | Flight #3 |
-| None (native 75mm) | M-class cert motor | Flight #4 |
+| None (native 75mm) | M1350W-PS | Flight #4 (cert) |
 
 Adapters can be 3D printed in PC CF or machined from phenolic/aluminum.
 
 ## Motor Selection
-
-### L3 Certification Motor (Flight #4)
-
-M-class motors are the minimum for L3. 75mm is the smallest available diameter for M-class single-use motors. 98mm is a fallback if 75mm options are insufficient.
-
-| Motor | Diameter | Total Impulse | Notes |
-|-------|----------|--------------|-------|
-| TBD | 75mm | M-class (5120-10240 N-s) | Research needed |
 
 ### Motor Type: Single-Use
 
@@ -106,7 +125,9 @@ The custom flight computer will be validated on flights #2 and #3 before the L3 
 
 ### Redundancy
 
-Following the L2 approach: electronic dual deployment as primary, with motor delay charge as independent safety backup.
+For flights #2 and #3 (with delay-equipped motors): electronic dual deployment as primary, with motor delay charge as independent safety backup.
+
+For flight #4 (M1350W-PS, plugged): **no motor backup available**. Recovery depends entirely on electronic deployment. This makes dual redundant electronics critical — consider flying two independent flight computers (primary + backup) for the cert flight.
 
 ## Airframe Design
 
@@ -221,11 +242,13 @@ This documentation will live in this repo initially. May move to a separate repo
 
 ## Open Questions
 
-1. Specific 75mm single-use M motor selection for cert flight
+1. ~~Specific 75mm single-use M motor selection for cert flight~~ → AeroTech M1350W-PS
 2. Airframe material and diameter
 3. Nose cone — 3D printed or purchased?
 4. Custom flight computer detailed design
 5. Second TAP member
 6. Launch site — Enköping (SMRK) or elsewhere?
 7. J420R weight budget — will L3 airframe stay under 8.56 kg for 5:1 T/W?
-8. Timeline
+8. Dual redundant electronics for cert flight (plugged motor, no backup)?
+9. Motor procurement logistics — M1350W-PS requires L3 cert to buy
+10. Timeline

--- a/docs/certification/l3-planning.md
+++ b/docs/certification/l3-planning.md
@@ -6,9 +6,11 @@ L1 and L2 were verification that fundamentals were understood correctly — kit-
 
 ## Requirements
 
-Per Tripoli L3 certification:
+Per [Tripoli L3 certification rules](https://www.tripoli.org/Level3):
 
 - [x] Current L2 certification
+- [ ] **3 flights on L2 impulse range** (J/K/L motors), documented in Tripoli Flight Log (L2 to L3)
+- [ ] **At least 2 of those flights must use electronic deployment** (electronic flight controller controlling parachute ejection — motor-ejected chute with electronic release does NOT count)
 - [ ] Written project report reviewed by 2 TAP members before flight
 - [ ] Scratch-built rocket (no kits)
 - [ ] Successfully fly and recover using M, N, or O motor
@@ -21,11 +23,64 @@ Per Tripoli L3 certification:
 | TAP member #1 | Rolf Örell (TRA# 3728) | Confirmed |
 | TAP member #2 | TBD | Rolf to introduce |
 
+## Flight Progression
+
+Incremental approach: build the L3 airframe early, fly it on progressively larger motors to validate the design before the certification flight.
+
+| # | Motor | Diameter | Adapter | Airframe | Purpose | Electronic | Status |
+|---|-------|----------|---------|----------|---------|------------|--------|
+| 1 | AeroTech J350 | 38mm | — | Peregrine | L2 certification | ✓ CATS Vega | ✅ Done |
+| 2 | AeroTech J420R | 38mm | 75→38mm | L3 airframe | Test new airframe, electronic deploy #2 | ✓ Custom FC | Planned |
+| 3 | AeroTech L1000W | 54mm | 75→54mm | L3 airframe | Stress test at higher impulse, electronic deploy #3 | ✓ Custom FC | Planned |
+| 4 | TBD M-class | 75mm | None | L3 airframe | **L3 certification flight** | ✓ Custom FC | Planned |
+
+### Flight #2: J420R in L3 Airframe
+
+Thrust-to-weight check: J420R average thrust 420N, 5:1 minimum ratio → max liftoff mass 8.56 kg. The L3 airframe will be heavier than the Peregrine but without the M-class motor. Need to keep dry weight + adapter + J420R motor weight under 8.5 kg. May be tight — requires weight estimate once airframe design is more mature.
+
+### Flight #3: L1000W Stress Test
+
+The AeroTech L1000W-18A is the primary candidate for the L-class stress test flight:
+
+| Parameter | Value |
+|-----------|-------|
+| Designation | HP-L1000W |
+| Diameter | 54mm |
+| Length | 635mm |
+| Total impulse | 2714 N-s (mid L-class) |
+| Average thrust | 1000 N |
+| Max thrust | 1261 N |
+| Burn time | 2.7 s |
+| Total weight | 2194 g |
+| Propellant | White Lightning |
+| Type | Single-use DMS |
+| Delay | 10-18s adjustable (UDDT required) |
+
+Thrust-to-weight: 1000N average, 5:1 minimum → max liftoff mass 20.4 kg. Very generous margin.
+
+This flight validates the airframe under significantly higher loads and speeds before committing to the M-class cert flight.
+
+### Motor Adapter Strategy
+
+The 75mm motor mount is the native size for the L3 cert flight. Smaller motors require centering adapters:
+
+| Adapter | For Motors | Flights |
+|---------|-----------|---------|
+| 75mm → 38mm | J420R and other 38mm J motors | Flight #2 |
+| 75mm → 54mm | L1000W and other 54mm L motors | Flight #3 |
+| None (native 75mm) | M-class cert motor | Flight #4 |
+
+Adapters can be 3D printed in PC CF or machined from phenolic/aluminum.
+
 ## Motor Selection
 
-### Sizing Constraints
+### L3 Certification Motor (Flight #4)
 
-M-class motors are the minimum for L3. These are not available below 75mm diameter. 98mm is also an option but drives a larger rocket. Since high power is not the goal (just meeting requirements), 75mm is preferred to keep the rocket as small as practical.
+M-class motors are the minimum for L3. 75mm is the smallest available diameter for M-class single-use motors. 98mm is a fallback if 75mm options are insufficient.
+
+| Motor | Diameter | Total Impulse | Notes |
+|-------|----------|--------------|-------|
+| TBD | 75mm | M-class (5120-10240 N-s) | Research needed |
 
 ### Motor Type: Single-Use
 
@@ -36,13 +91,22 @@ Single-use (disposable casing) rather than reloadable, for several reasons:
 - Simpler preparation on launch day
 - Acceptable cost for a one-off certification flight
 
-### Candidate Motors
+## Electronics
 
-| Motor | Diameter | Total Impulse | Notes |
-|-------|----------|--------------|-------|
-| TBD | 75mm | M-class (5120-10240 N-s) | Research needed |
+### Custom Flight Computer
 
-98mm single-use motors are a fallback if 75mm options are insufficient.
+A custom flight computer will be developed, based on the CATS Vega design but with improvements:
+
+- **Improved power-up system**: Based on power management approach used for NASA Centennial Challenge robots — details TBD
+- **Dual pyro channels**: For drogue and main deployment
+- **Data logging**: Barometer, IMU, full flight telemetry
+- Open source design, custom PCB
+
+The custom flight computer will be validated on flights #2 and #3 before the L3 cert flight.
+
+### Redundancy
+
+Following the L2 approach: electronic dual deployment as primary, with motor delay charge as independent safety backup.
 
 ## Airframe Design
 
@@ -132,6 +196,10 @@ Fin flutter is the critical structural concern for L3. M-class motors produce si
 
 PeregrineFin v0.7.0 analysis: span 137mm, area 23222mm², safety factor 1.65 at 10° AoA, flutter-safe to K-class motors with carbon rod reinforcement. L3 fin design must exceed this analysis for M-class speeds.
 
+### Validation Through Flight Progression
+
+The stepped flight approach (J → L → M) provides empirical validation of fin structural integrity at progressively higher speeds before the cert flight.
+
 ## Documentation Package
 
 Tripoli L3 requires a comprehensive written project report. Planned sections:
@@ -140,11 +208,12 @@ Tripoli L3 requires a comprehensive written project report. Planned sections:
 - [ ] Stability analysis (CP/CG calculations, margin)
 - [ ] Structural analysis (fin flutter, airframe loads)
 - [ ] Recovery system design (dual deploy, redundancy)
-- [ ] Electronics and avionics
+- [ ] Electronics and avionics (custom flight computer design)
 - [ ] Construction documentation with photos
 - [ ] Ground testing results
 - [ ] Flight simulation results
 - [ ] Safety analysis
+- [ ] L2 flight log (3 flights, demonstrating electronic deployment)
 
 ### Repository
 
@@ -152,10 +221,11 @@ This documentation will live in this repo initially. May move to a separate repo
 
 ## Open Questions
 
-1. Specific 75mm single-use M motor selection
+1. Specific 75mm single-use M motor selection for cert flight
 2. Airframe material and diameter
 3. Nose cone — 3D printed or purchased?
-4. Recovery system design (likely similar to L2: dual deploy with CATS Vega)
+4. Custom flight computer detailed design
 5. Second TAP member
 6. Launch site — Enköping (SMRK) or elsewhere?
-7. Timeline
+7. J420R weight budget — will L3 airframe stay under 8.56 kg for 5:1 T/W?
+8. Timeline


### PR DESCRIPTION
## L3 Flight Progression and Motor Details

Major update to L3 planning with concrete flight progression strategy and motor selections.

### Changes to `docs/certification/l3-planning.md`

**Tripoli L2-to-L3 flight requirements** (from tripoli.org/Level3):
- 3 flights on L2 impulse range (J/K/L)
- At least 2 must use electronic deployment
- Motor-ejected chute with electronic release does NOT count

**Stepped flight progression**:
1. J350 / Peregrine — L2 cert ✅ done
2. J420R / L3 airframe (75→38mm adapter) — test new airframe
3. L1000W-18A / L3 airframe (75→54mm adapter) — stress test
4. M-class / L3 airframe (native 75mm) — L3 cert flight

**AeroTech L1000W-18A** for Flight #3: 54mm single-use DMS, 2714 N-s, 1000N avg thrust, 2.7s burn. Max liftoff mass 20.4 kg at 5:1 T/W.

**Motor adapter strategy**: 75mm native mount with 75→54mm and 75→38mm adapters for progressive testing.

**J420R T/W analysis**: 420N avg → max 8.56 kg liftoff. Flagged as potentially tight for L3 airframe.

**Custom flight computer**: CATS Vega clone with improved power-up system (from NASA Centennial Challenge robot experience). Validated on flights #2 and #3 before cert.

**Flutter validation**: Stepped flights provide empirical structural validation at progressively higher speeds.