### PR TITLE
Clarify L2 main-altitude: configured 150m, fired at 146m due to safety counter

### DIFF
--- a/docs/flight/flight2-analysis.md
+++ b/docs/flight/flight2-analysis.md
@@ -44,7 +44,14 @@ Dual deployment was mandatory for L2 because of the 500 m landing-radius rule (s
 | Under drogue (18") | 63.6 s | **13.17 m/s** (median 13.19) | Drogue descent from 986 m to 146 m |
 | Under main (48") | 25.5 s | **6.34 m/s** (median 6.13) | Main from 146 m to ground |
 
-The main charge fired at **146 m AGL**, matching the configured CATS Vega `main_altitude` setting. Touchdown velocity of 0.5 m/s indicates a clean, well-cushioned landing.
+The main charge fired at **146 m AGL** after the rocket descended through the configured **`main_altitude` = 150 m** threshold. The 4 m gap is the firmware's `MAIN_SAFETY_COUNTER = 30` hold: the FSM requires altitude < threshold for 30 consecutive 100 Hz samples (≈ 0.3 s) before transitioning to MAIN to reject barometer noise. At a ~13 m/s descent rate, the rocket dropped 4 m during the hold:
+
+| Event | ts (ms) | Altitude | Note |
+|-------|---------|----------|------|
+| First sample below threshold | 200810 | 149.94 m | `memory[0]` starts counting |
+| `memory[0] > 30`, MAIN fired | 201130 | 145.94 m | 320 ms / 32 samples later |
+
+The CATS Vega factory default `main_altitude` is 200 m (per `flight_computer/src/config/cats_config.cpp`); this rocket was configured to 150 m via the CATS Configurator. Touchdown velocity of 0.5 m/s indicates a clean, well-cushioned landing.
 
 The drogue descent rate of ~13 m/s is in the expected range for a small drogue on a 3.1 kg rocket — the drogue's job is to keep the rocket vertical and prevent zipper, not to slow it significantly.
 


### PR DESCRIPTION
## Summary

Fixes a misleading paragraph in `docs/flight/flight2-analysis.md`. The previous wording said the main charge "fired at 146 m AGL, matching the configured CATS Vega \`main_altitude\` setting" — which implied the configured altitude was 146 m. It wasn't.

Reading the firmware logic and the flight data together:

- Configured \`main_altitude\` = **150 m** (set via CATS Configurator; CATS factory default is actually 200 m, not 100 m as commonly assumed)
- Rocket first crossed 150 m at ts=200810 (altitude 149.94 m)
- Firmware's \`MAIN_SAFETY_COUNTER = 30\` holds for 30 consecutive 100 Hz samples below threshold before transitioning to MAIN — this is the noise-rejection guard
- 32 samples (320 ms) later, at ts=201130, FSM transitioned to MAIN with altitude 145.94 m
- The 4 m gap is the descent at ~13 m/s during the 0.3 s safety-counter hold

The analysis page now documents this correctly with a small table of the transition timeline.

## Test plan

- [x] Reviewed firmware: `flight_computer/src/control/flight_phases.cpp` and `flight_phases.hpp` confirm `MAIN_SAFETY_COUNTER = 30` with 100 Hz control loop
- [x] Verified configured value cannot be 100 m (rocket would have fired at 96 m, not 146 m) or 200 m (would have fired ~4 s earlier at ts ≈ 197160)
- [x] 30-sample × 10 ms × 13 m/s ≈ 4 m matches the observed 150 m → 146 m drop