### PR TITLE
Site redesign: Mission Control theme

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -35,12 +35,8 @@ Built in Estonia · flown at Enköping, Sweden · next objective: L3</p>
 <p class="mc-label">Mission log</p>
 
 <div class="mc-log" markdown>
-<div class="mc-log-row" markdown>
-<span class="mc-log-ok">✓</span><span class="mc-log-date">2026-02-22</span><span class="mc-log-title">FLIGHT 02 — L2 CERTIFICATION</span><span class="mc-log-detail">J350 · DUAL DEPLOY · NOMINAL</span>[REPORT →](flight/flight2-analysis.md)
-</div>
-<div class="mc-log-row" markdown>
-<span class="mc-log-ok">✓</span><span class="mc-log-date">2026-01-24</span><span class="mc-log-title">FLIGHT 01 — L1 CERTIFICATION</span><span class="mc-log-detail">H128W · 140.8 M · MOTOR EJECT</span>[REPORT →](flight/flight1-analysis.md)
-</div>
+<div class="mc-log-row" markdown="span"><span class="mc-log-ok">✓</span><span class="mc-log-date">2026-02-22</span><span class="mc-log-title">FLIGHT 02 — L2 CERTIFICATION</span><span class="mc-log-detail">J350 · DUAL DEPLOY · NOMINAL</span>[REPORT →](flight/flight2-analysis.md)</div>
+<div class="mc-log-row" markdown="span"><span class="mc-log-ok">✓</span><span class="mc-log-date">2026-01-24</span><span class="mc-log-title">FLIGHT 01 — L1 CERTIFICATION</span><span class="mc-log-detail">H128W · 140.8 M · MOTOR EJECT</span>[REPORT →](flight/flight1-analysis.md)</div>
 </div>
 
 <p class="mc-label">Documentation</p>
@@ -78,7 +74,7 @@ Built in Estonia · flown at Enköping, Sweden · next objective: L3</p>
 </div>
 </div>
 
-<div class="mc-links" markdown>
+<div class="mc-links" markdown="span">
 [Configurations](configurations.md)
 [Decisions](decisions/index.md)
 [Blog](blog/index.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,76 +1,95 @@
-# Peregrine
-
-<div class="hero" markdown>
-
-**Tripoli Level 2 Certified** ✓
-
-Apogee Peregrine dual deployment rocket • Tripoli #38105 • Estonia → Sweden
-
-</div>
-
+---
+hide:
+  - navigation
+  - toc
 ---
 
-<div class="grid" markdown>
+<div class="mc-hero" markdown>
+<p class="mc-eyebrow">Mission Status <span class="mc-led"></span> All Systems Nominal</p>
 
-<div class="card" markdown>
-### L2 Flight
-| | |
-|---|---|
-| **Date** | 22 Feb 2026 |
-| **Location** | Enköping, Sweden |
-| **Motor** | J350 |
-| **Weight** | 3100 g |
-| **Recovery** | Dual deploy |
+# SIPSIK — Tripoli L2 Certified
+
+<p class="mc-sub">Apogee Peregrine · 100 mm · dual deploy via CATS Vega<br>
+Built in Estonia · flown at Enköping, Sweden · next objective: L3</p>
 </div>
 
-<div class="card" markdown>
-### L1 Flight
-| | |
-|---|---|
-| **Date** | 24 Jan 2026 |
-| **Location** | Enköping, Sweden |
-| **Motor** | H128W-14A |
-| **Altitude** | 140.8 m |
-| **Recovery** | Motor ejection |
+<div class="mc-telemetry" markdown>
+<div class="mc-tile" markdown>
+<div class="mc-tile-label">Certs complete</div>
+<div class="mc-tile-value">L1 + L2</div>
+</div>
+<div class="mc-tile" markdown>
+<div class="mc-tile-label">Last motor</div>
+<div class="mc-tile-value">J350</div>
+</div>
+<div class="mc-tile" markdown>
+<div class="mc-tile-label">Liftoff mass</div>
+<div class="mc-tile-value">3100 g</div>
+</div>
+<div class="mc-tile" markdown>
+<div class="mc-tile-label">Main deploy</div>
+<div class="mc-tile-value">146 m</div>
+</div>
 </div>
 
-<div class="card" markdown>
-### Status
-<span class="status status-complete">L2 CERTIFIED</span>
+<p class="mc-label">Mission log</p>
 
-Tripoli #38105
-L1: 24 Jan 2026
-L2: 22 Feb 2026
+<div class="mc-log" markdown>
+<div class="mc-log-row" markdown>
+<span class="mc-log-ok">✓</span><span class="mc-log-date">2026-02-22</span><span class="mc-log-title">FLIGHT 02 — L2 CERTIFICATION</span><span class="mc-log-detail">J350 · DUAL DEPLOY · NOMINAL</span>[REPORT →](flight/flight2-analysis.md)
+</div>
+<div class="mc-log-row" markdown>
+<span class="mc-log-ok">✓</span><span class="mc-log-date">2026-01-24</span><span class="mc-log-title">FLIGHT 01 — L1 CERTIFICATION</span><span class="mc-log-detail">H128W · 140.8 M · MOTOR EJECT</span>[REPORT →](flight/flight1-analysis.md)
+</div>
 </div>
 
+<p class="mc-label">Documentation</p>
+
+<div class="mc-doc-grid" markdown>
+<div class="mc-doc-card" markdown>
+<div class="mc-doc-num">01</div>
+### [Certification](certification/index.md)
+<p>L1 ✓ · L2 ✓ · L3 planning</p>
+</div>
+<div class="mc-doc-card" markdown>
+<div class="mc-doc-num">02</div>
+### [Construction](construction/build-log.md)
+<p>Build log · ebay · fins · recovery</p>
+</div>
+<div class="mc-doc-card" markdown>
+<div class="mc-doc-num">03</div>
+### [Calculations](calculations/stability.md)
+<p>Stability · BP charges · vent holes</p>
+</div>
+<div class="mc-doc-card" markdown>
+<div class="mc-doc-num">04</div>
+### [Simulations](simulations/openrocket.md)
+<p>OpenRocket · motor selection</p>
+</div>
+<div class="mc-doc-card" markdown>
+<div class="mc-doc-num">05</div>
+### [Flight](flight/log.md)
+<p>Checklists · logs · analysis</p>
+</div>
+<div class="mc-doc-card" markdown>
+<div class="mc-doc-num">06</div>
+### [Photos](photos/index.md)
+<p>Build & launch gallery</p>
+</div>
 </div>
 
----
+<div class="mc-links" markdown>
+[Configurations](configurations.md)
+[Decisions](decisions/index.md)
+[Blog](blog/index.md)
+[References](references.md)
+</div>
 
-## L2 Certified
+## The Story Behind Sipsik
 
-This rocket, named **SIPSIK** after the beloved Estonian cartoon character, achieved Tripoli L2 certification on 22 February 2026 at Enköping, Sweden, flying on an AeroTech J350 with dual deployment recovery via CATS Vega.
-
-L1 certification was achieved one month earlier on 24 January 2026 at the same location.
-
-### The Story Behind Sipsik
+This rocket, named **SIPSIK** after the beloved Estonian cartoon character, achieved Tripoli L2 certification on 22 February 2026 at Enköping, Sweden, flying on an AeroTech J350 with dual deployment recovery via CATS Vega. L1 certification was achieved one month earlier on 24 January 2026 at the same location.
 
 The blue rocket connects to Estonian children's culture: in the Sipsik cartoon, a girl named Anu and her brother Mart build a cardboard rocket hoping to send their toy Sipsik to the moon. This rocket teaches my daughters Liza (5) and Elsa (2) how we *actually* send rockets to the sky.
-
-## Documentation
-
-This site documents the complete build and certification process:
-
-| Section | Description |
-|---------|-------------|
-| [**Certification**](certification/index.md) | L1 and L2 achieved |
-| [**Flight Log**](flight/log.md) | Flight data and analysis |
-| [**Specifications**](specifications/overview.md) | Detailed rocket specs |
-| [**Construction**](construction/build-log.md) | Build progress and techniques |
-| [**Calculations**](calculations/stability.md) | Stability, ejection charges |
-| [**Simulations**](simulations/openrocket.md) | OpenRocket predictions |
-| [**Photos**](photos/index.md) | Build and flight photography |
-| [**Decisions**](decisions/index.md) | Key technical decisions |
 
 ## Acknowledgments
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,127 +1,171 @@
-/* Custom styles for Peregrine L1 documentation */
+/* Mission Control theme — SIPSIK / Peregrine docs
+   Spec: specs/2026-07-11-site-redesign-design.md */
 
 :root {
-  --md-primary-fg-color: #3f51b5;
-  --md-primary-fg-color--light: #5c6bc0;
-  --md-primary-fg-color--dark: #303f9f;
-  --md-accent-fg-color: #536dfe;
+  --mc-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
-/* Better typography */
+/* ---------- tokens: dark (default) ---------- */
+[data-md-color-scheme="slate"] {
+  --mc-bg: #0a0e17;
+  --mc-panel: #0d1220;
+  --mc-border: #1f2937;
+  --mc-border-subtle: #131a2b;
+  --mc-text: #f8fafc;
+  --mc-body: #cbd5e1;
+  --mc-muted: #94a3b8;
+  --mc-faint: #64748b;
+  --mc-accent: #fbbf24;
+  --mc-accent-soft: rgba(251, 191, 36, 0.07);
+  --mc-success: #34d399;
+  --mc-info: #22d3ee;
+  --mc-danger: #f87171;
+  --mc-scanline: rgba(148, 163, 184, 0.05);
+
+  /* map tokens onto Material */
+  --md-default-bg-color: var(--mc-bg);
+  --md-default-fg-color: var(--mc-text);
+  --md-default-fg-color--light: var(--mc-body);
+  --md-default-fg-color--lighter: var(--mc-muted);
+  --md-default-fg-color--lightest: var(--mc-border);
+  --md-primary-fg-color: var(--mc-panel);
+  --md-primary-fg-color--dark: var(--mc-panel);
+  --md-primary-bg-color: var(--mc-text);
+  --md-primary-bg-color--light: var(--mc-muted);
+  --md-accent-fg-color: var(--mc-accent);
+  --md-accent-fg-color--transparent: var(--mc-accent-soft);
+  --md-typeset-a-color: var(--mc-accent);
+  --md-code-bg-color: var(--mc-panel);
+  --md-code-fg-color: #e2e8f0;
+  --md-footer-bg-color: var(--mc-panel);
+  --md-footer-bg-color--dark: var(--mc-bg);
+  --md-footer-fg-color: var(--mc-muted);
+  --md-footer-fg-color--light: var(--mc-faint);
+  --md-footer-fg-color--lighter: var(--mc-faint);
+}
+
+/* ---------- tokens: light (toggle) ---------- */
+[data-md-color-scheme="default"] {
+  --mc-bg: #faf9f7;
+  --mc-panel: #f1efeb;
+  --mc-border: #e2ded6;
+  --mc-border-subtle: #ece9e3;
+  --mc-text: #16181d;
+  --mc-body: #333944;
+  --mc-muted: #5f6672;
+  --mc-faint: #8a8f99;
+  --mc-accent: #b45309;
+  --mc-accent-soft: rgba(180, 83, 9, 0.08);
+  --mc-success: #047857;
+  --mc-info: #0e7490;
+  --mc-danger: #b91c1c;
+  --mc-scanline: rgba(22, 24, 29, 0.04);
+
+  --md-default-bg-color: var(--mc-bg);
+  --md-default-fg-color: var(--mc-text);
+  --md-default-fg-color--light: var(--mc-body);
+  --md-default-fg-color--lighter: var(--mc-muted);
+  --md-default-fg-color--lightest: var(--mc-border);
+  --md-primary-fg-color: var(--mc-panel);
+  --md-primary-fg-color--dark: var(--mc-panel);
+  --md-primary-bg-color: var(--mc-text);
+  --md-primary-bg-color--light: var(--mc-muted);
+  --md-accent-fg-color: var(--mc-accent);
+  --md-accent-fg-color--transparent: var(--mc-accent-soft);
+  --md-typeset-a-color: var(--mc-accent);
+  --md-code-bg-color: var(--mc-panel);
+  --md-code-fg-color: #1f2430;
+  --md-footer-bg-color: var(--mc-panel);
+  --md-footer-bg-color--dark: var(--mc-bg);
+  --md-footer-fg-color: var(--mc-muted);
+  --md-footer-fg-color--light: var(--mc-faint);
+  --md-footer-fg-color--lighter: var(--mc-faint);
+}
+
+/* ---------- header & nav tabs ---------- */
+.md-header {
+  border-bottom: 1px solid var(--mc-border);
+  box-shadow: none;
+}
+
+.md-header__topic {
+  font-family: var(--mc-mono);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+}
+
+.md-tabs {
+  border-bottom: 1px solid var(--mc-border);
+}
+
+.md-tabs__link {
+  font-family: var(--mc-mono);
+  font-size: 0.58rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  opacity: 0.75;
+}
+
+.md-tabs__link--active,
+.md-tabs__item--active .md-tabs__link {
+  color: var(--mc-accent);
+  border-bottom: 2px solid var(--mc-accent);
+  opacity: 1;
+}
+
+/* search box */
+.md-search__form {
+  border: 1px solid var(--mc-border);
+  border-radius: 6px;
+}
+
+/* ---------- sidebar navigation ---------- */
+.md-nav__title {
+  font-family: var(--mc-mono);
+  font-size: 0.55rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--mc-faint);
+}
+
+.md-nav__item .md-nav__link--active,
+.md-nav__item .md-nav__link--active code {
+  color: var(--mc-accent);
+}
+
+.md-nav__item .md-nav__link--active {
+  border-left: 2px solid var(--mc-accent);
+  background: var(--mc-accent-soft);
+  padding-left: 0.35rem;
+}
+
+/* ---------- footer ---------- */
+.md-footer {
+  border-top: 1px solid var(--mc-border);
+}
+
+.md-footer-meta {
+  font-family: var(--mc-mono);
+  font-size: 0.55rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+/* hide "made with mkdocs" */
+.md-footer-copyright {
+  display: none;
+}
+
+/* ---------- base typography ---------- */
 .md-typeset h1 {
   font-weight: 700;
   letter-spacing: -0.02em;
+  color: var(--mc-text);
 }
 
 .md-typeset h2 {
   font-weight: 600;
-  margin-top: 1.5em;
+  margin-top: 1.6em;
   padding-bottom: 0.3em;
-  border-bottom: 1px solid var(--md-default-fg-color--lightest);
-}
-
-/* Hero section on home page */
-.md-typeset .hero {
-  text-align: center;
-  padding: 2rem 0;
-  margin-bottom: 2rem;
-}
-
-.md-typeset .hero h1 {
-  font-size: 2.5rem;
-  margin-bottom: 0.5rem;
-}
-
-.md-typeset .hero p {
-  font-size: 1.2rem;
-  color: var(--md-default-fg-color--light);
-}
-
-/* Cards for grid layout */
-.md-typeset .grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: 1rem;
-  margin: 1.5rem 0;
-}
-
-.md-typeset .card {
-  padding: 1.5rem;
-  border-radius: 8px;
-  background: var(--md-code-bg-color);
-  border: 1px solid var(--md-default-fg-color--lightest);
-  transition: transform 0.2s, box-shadow 0.2s;
-}
-
-.md-typeset .card:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-}
-
-.md-typeset .card h3 {
-  margin-top: 0;
-  color: var(--md-primary-fg-color);
-}
-
-/* Better tables */
-.md-typeset table:not([class]) {
-  border-radius: 8px;
-  overflow: hidden;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
-}
-
-.md-typeset table:not([class]) th {
-  background: var(--md-primary-fg-color);
-  color: white;
-  font-weight: 600;
-}
-
-/* Status badges */
-.md-typeset .status {
-  display: inline-block;
-  padding: 0.2em 0.6em;
-  border-radius: 4px;
-  font-size: 0.85em;
-  font-weight: 500;
-}
-
-.md-typeset .status-pending {
-  background: #fff8e1;
-  color: #f57c00;
-}
-
-.md-typeset .status-complete {
-  background: #e8f5e9;
-  color: #2e7d32;
-}
-
-.md-typeset .status-inprogress {
-  background: #e3f2fd;
-  color: #1565c0;
-}
-
-/* Image styling */
-.md-typeset img {
-  border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
-}
-
-/* Admonition improvements */
-.md-typeset .admonition {
-  border-radius: 8px;
-}
-
-/* Footer cleanup */
-.md-footer-meta {
-  background: var(--md-primary-fg-color--dark);
-}
-
-/* Quick specs table on home */
-.md-typeset .specs-table {
-  max-width: 500px;
-}
-
-/* Hide "made with mkdocs" */
-.md-footer-copyright {
-  display: none;
+  border-bottom: 1px solid var(--mc-border);
 }

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -219,7 +219,11 @@
 /* type colors: note/info/question = cyan */
 .md-typeset .admonition.note,
 .md-typeset .admonition.info,
-.md-typeset .admonition.question {
+.md-typeset .admonition.question,
+.md-typeset details.note,
+.md-typeset details.info,
+.md-typeset details.question {
+  border-color: var(--mc-border);
   border-left-color: var(--mc-info);
 }
 .md-typeset .note > .admonition-title,
@@ -230,7 +234,10 @@
 
 /* tip/success = green */
 .md-typeset .admonition.tip,
-.md-typeset .admonition.success {
+.md-typeset .admonition.success,
+.md-typeset details.tip,
+.md-typeset details.success {
+  border-color: var(--mc-border);
   border-left-color: var(--mc-success);
 }
 .md-typeset .tip > .admonition-title,
@@ -240,7 +247,10 @@
 
 /* warning/important = amber */
 .md-typeset .admonition.warning,
-.md-typeset .admonition.important {
+.md-typeset .admonition.important,
+.md-typeset details.warning,
+.md-typeset details.important {
+  border-color: var(--mc-border);
   border-left-color: var(--mc-accent);
 }
 .md-typeset .warning > .admonition-title,
@@ -250,7 +260,10 @@
 
 /* danger/failure = red */
 .md-typeset .admonition.danger,
-.md-typeset .admonition.failure {
+.md-typeset .admonition.failure,
+.md-typeset details.danger,
+.md-typeset details.failure {
+  border-color: var(--mc-border);
   border-left-color: var(--mc-danger);
 }
 .md-typeset .danger > .admonition-title,

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -169,3 +169,143 @@
   padding-bottom: 0.3em;
   border-bottom: 1px solid var(--mc-border);
 }
+
+/* ---------- tables ---------- */
+.md-typeset table:not([class]) {
+  border: 1px solid var(--mc-border);
+  border-radius: 6px;
+  box-shadow: none;
+}
+
+.md-typeset table:not([class]) th {
+  background: transparent;
+  color: var(--mc-faint);
+  font-family: var(--mc-mono);
+  font-size: 0.58rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  border-bottom: 2px solid var(--mc-accent);
+}
+
+.md-typeset table:not([class]) td {
+  border-top: 1px solid var(--mc-border-subtle);
+}
+
+/* ---------- admonitions: flat console panels ---------- */
+.md-typeset .admonition,
+.md-typeset details {
+  background: var(--mc-panel);
+  border: 1px solid var(--mc-border);
+  border-left-width: 3px;
+  border-radius: 6px;
+  box-shadow: none;
+}
+
+.md-typeset .admonition-title,
+.md-typeset summary {
+  background: transparent !important;
+  font-family: var(--mc-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.58rem;
+}
+
+/* icons inherit the title color */
+.md-typeset .admonition-title::before,
+.md-typeset summary::before {
+  background-color: currentColor !important;
+}
+
+/* type colors: note/info/question = cyan */
+.md-typeset .admonition.note,
+.md-typeset .admonition.info,
+.md-typeset .admonition.question {
+  border-left-color: var(--mc-info);
+}
+.md-typeset .note > .admonition-title,
+.md-typeset .info > .admonition-title,
+.md-typeset .question > .admonition-title {
+  color: var(--mc-info);
+}
+
+/* tip/success = green */
+.md-typeset .admonition.tip,
+.md-typeset .admonition.success {
+  border-left-color: var(--mc-success);
+}
+.md-typeset .tip > .admonition-title,
+.md-typeset .success > .admonition-title {
+  color: var(--mc-success);
+}
+
+/* warning/important = amber */
+.md-typeset .admonition.warning,
+.md-typeset .admonition.important {
+  border-left-color: var(--mc-accent);
+}
+.md-typeset .warning > .admonition-title,
+.md-typeset .important > .admonition-title {
+  color: var(--mc-accent);
+}
+
+/* danger/failure = red */
+.md-typeset .admonition.danger,
+.md-typeset .admonition.failure {
+  border-left-color: var(--mc-danger);
+}
+.md-typeset .danger > .admonition-title,
+.md-typeset .failure > .admonition-title {
+  color: var(--mc-danger);
+}
+
+/* ---------- display math (MathJax / arithmatex) ---------- */
+.md-typeset div.arithmatex {
+  background: var(--mc-panel);
+  border-left: 2px solid var(--mc-accent);
+  border-radius: 0 6px 6px 0;
+  padding: 0.7em 1em;
+  overflow-x: auto;
+}
+
+/* ---------- code blocks ---------- */
+.md-typeset pre {
+  border: 1px solid var(--mc-border);
+  border-radius: 6px;
+}
+
+/* ---------- images (skip inline emoji) ---------- */
+.md-typeset img:not(.twemoji) {
+  border-radius: 6px;
+  border: 1px solid var(--mc-border);
+  box-shadow: none;
+}
+
+/* ---------- status badges ---------- */
+.md-typeset .status {
+  display: inline-block;
+  font-family: var(--mc-mono);
+  font-size: 0.55rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  padding: 0.25em 0.7em;
+  border-radius: 4px;
+  border: 1px solid;
+}
+
+.md-typeset .status-complete {
+  color: var(--mc-success);
+  border-color: var(--mc-success);
+  background: transparent;
+}
+
+.md-typeset .status-pending {
+  color: var(--mc-accent);
+  border-color: var(--mc-accent);
+  background: transparent;
+}
+
+.md-typeset .status-inprogress {
+  color: var(--mc-info);
+  border-color: var(--mc-info);
+  background: transparent;
+}

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -309,3 +309,160 @@
   border-color: var(--mc-info);
   background: transparent;
 }
+
+/* ---------- home page: mission control components ---------- */
+.mc-hero {
+  padding: 2.2rem 0 1.6rem;
+  background:
+    radial-gradient(60rem 16rem at 15% 0%, var(--mc-accent-soft), transparent),
+    repeating-linear-gradient(0deg, transparent 0 23px, var(--mc-scanline) 23px 24px);
+}
+
+.mc-eyebrow {
+  font-family: var(--mc-mono);
+  font-size: 0.6rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--mc-accent);
+  margin-bottom: 0.6rem;
+}
+
+.mc-led {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--mc-success);
+  box-shadow: 0 0 8px var(--mc-success);
+  margin: 0 0.3em;
+}
+
+.md-typeset .mc-hero h1 {
+  font-size: 1.9rem;
+  margin: 0 0 0.4rem;
+}
+
+.mc-sub {
+  font-family: var(--mc-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--mc-muted);
+  line-height: 1.8;
+}
+
+.mc-telemetry {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 1px;
+  background: var(--mc-border);
+  border: 1px solid var(--mc-border);
+  border-radius: 8px;
+  overflow: hidden;
+  margin: 1.4rem 0;
+}
+
+.md-typeset .mc-tile {
+  background: var(--mc-panel);
+  padding: 0.9rem 1rem;
+  margin: 0;
+}
+
+.mc-tile-label {
+  font-family: var(--mc-mono);
+  font-size: 0.52rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--mc-faint);
+}
+
+.mc-tile-value {
+  font-family: var(--mc-mono);
+  font-size: 1.05rem;
+  color: var(--mc-accent);
+  margin-top: 0.3rem;
+}
+
+.md-typeset .mc-label {
+  font-family: var(--mc-mono);
+  font-size: 0.55rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--mc-faint);
+  margin: 1.6rem 0 0.6rem;
+}
+
+.mc-log {
+  border-top: 1px solid var(--mc-border);
+}
+
+.md-typeset .mc-log-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+  align-items: baseline;
+  padding: 0.55rem 0;
+  margin: 0;
+  border-bottom: 1px solid var(--mc-border-subtle);
+  font-family: var(--mc-mono);
+  font-size: 0.62rem;
+}
+
+.mc-log-ok { color: var(--mc-success); }
+.mc-log-date { color: var(--mc-muted); }
+.mc-log-title { color: var(--mc-text); }
+.mc-log-detail { color: var(--mc-faint); }
+.md-typeset .mc-log-row a { margin-left: auto; }
+
+.mc-doc-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  gap: 0.7rem;
+  margin: 0.8rem 0 1.6rem;
+}
+
+.md-typeset .mc-doc-card {
+  background: var(--mc-panel);
+  border: 1px solid var(--mc-border);
+  border-radius: 8px;
+  padding: 0.9rem 1rem;
+  margin: 0;
+  transition: border-color 0.15s;
+}
+
+.md-typeset .mc-doc-card:hover {
+  border-color: var(--mc-accent);
+}
+
+.mc-doc-num {
+  font-family: var(--mc-mono);
+  font-size: 0.55rem;
+  color: var(--mc-accent);
+}
+
+.md-typeset .mc-doc-card h3 {
+  margin: 0.25rem 0 0.2rem;
+  font-size: 0.78rem;
+  font-family: var(--mc-mono);
+  letter-spacing: 0.06em;
+}
+
+.md-typeset .mc-doc-card h3 a {
+  color: var(--mc-text);
+}
+
+.md-typeset .mc-doc-card p {
+  margin: 0;
+  font-size: 0.6rem;
+  color: var(--mc-faint);
+  font-family: var(--mc-mono);
+}
+
+.md-typeset .mc-links {
+  font-family: var(--mc-mono);
+  font-size: 0.62rem;
+  display: flex;
+  gap: 1.2rem;
+  flex-wrap: wrap;
+  margin-bottom: 1.6rem;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: Peregrine
+site_name: SIPSIK
 site_description: Tõnu's Tripoli L1, L2 & L3 certification rocket build documentation
 site_author: Tõnu Samuel
 site_url: https://tonuonu.github.io/MyLevel1Peregrine/
@@ -27,20 +27,18 @@ theme:
     - content.tabs.link
     - toc.follow
   palette:
-    - media: "(prefers-color-scheme: light)"
-      scheme: default
-      primary: indigo
-      accent: indigo
+    - scheme: slate
+      primary: custom
+      accent: custom
       toggle:
-        icon: material/brightness-7
-        name: Switch to dark mode
-    - media: "(prefers-color-scheme: dark)"
-      scheme: slate
-      primary: indigo
-      accent: indigo
-      toggle:
-        icon: material/brightness-4
+        icon: material/weather-night
         name: Switch to light mode
+    - scheme: default
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to dark mode
   icon:
     repo: fontawesome/brands/github
 

--- a/plans/2026-07-11-site-redesign.md
+++ b/plans/2026-07-11-site-redesign.md
@@ -1,0 +1,825 @@
+# Mission Control Site Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restyle the entire MkDocs site to the approved "Mission Control / Amber" dark-first console aesthetic per `specs/2026-07-11-site-redesign-design.md`.
+
+**Architecture:** Pure theme-layer change on MkDocs Material 9.7.6 — flip the palette to dark-default in `mkdocs.yml`, rewrite `docs/stylesheets/extra.css` around a console token set (CSS custom properties for both schemes), and rebuild `docs/index.md` as a mission-control landing page. No Jinja overrides, no new fonts, no new dependencies.
+
+**Tech Stack:** MkDocs 1.6.1, mkdocs-material 9.7.6 (`/usr/local/bin/mkdocs`), CSS custom properties, Markdown with `attr_list` + `md_in_html`.
+
+## Global Constraints
+
+- Work on branch `feature/site-redesign`; never push to `main`; end with a PR and STOP (no merge).
+- NO attribution lines anywhere: no `Co-Authored-By: Claude`, no `🤖 Generated with…` in commits or the PR body — strip them from any tool-suggested template.
+- Only these files may change: `mkdocs.yml`, `docs/stylesheets/extra.css`, `docs/index.md` (plus checkbox ticks in `plans/2026-07-11-site-redesign.md`).
+- Design tokens verbatim from the spec — dark: bg `#0a0e17`, panel `#0d1220`, border `#1f2937`, border-subtle `#131a2b`, text `#f8fafc`, body `#cbd5e1`, muted `#94a3b8`, faint `#64748b`, accent `#fbbf24`, success `#34d399`, info `#22d3ee`; light: bg `#faf9f7`, panel `#f1efeb`, ink `#16181d`, borders `#e2ded6`, accent `#b45309`, success `#047857`.
+- Fonts stay Inter (body) + JetBrains Mono (data/code). No font additions.
+- `mkdocs build` must stay warning-clean relative to the baseline captured in Task 1.
+
+---
+
+### Task 1: Dark-first palette + site identity (`mkdocs.yml`)
+
+**Files:**
+- Modify: `mkdocs.yml:1` (site_name) and `mkdocs.yml:29-43` (palette block)
+
+**Interfaces:**
+- Produces: color schemes `slate` (default) and `default` (toggle) with `primary: custom` / `accent: custom` — Tasks 2–4 hang all CSS off `[data-md-color-scheme="slate"]` and `[data-md-color-scheme="default"]`.
+
+- [ ] **Step 1: Capture baseline build log**
+
+```bash
+cd /Users/tonu/MyLevel1Peregrine
+mkdocs build 2>&1 | tee /private/tmp/claude-501/-Users-tonu-MyLevel1Peregrine/b9a5f7da-ea26-491d-9aac-bafcdf538158/scratchpad/baseline-build.log
+```
+
+Expected: exits 0. Note any pre-existing WARNING lines — they are the baseline.
+
+- [ ] **Step 2: Edit `mkdocs.yml`**
+
+Change line 1:
+
+```yaml
+site_name: SIPSIK
+```
+
+Replace the whole `palette:` block (currently lines 29–43, the two `media:`-keyed entries) with:
+
+```yaml
+  palette:
+    - scheme: slate
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/weather-night
+        name: Switch to light mode
+    - scheme: default
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to dark mode
+```
+
+Note: no `media:` keys — the first entry (slate) becomes the default for everyone regardless of OS preference, per spec "dark by default".
+
+- [ ] **Step 3: Rebuild and diff against baseline**
+
+```bash
+mkdocs build 2>&1 | tee /private/tmp/claude-501/-Users-tonu-MyLevel1Peregrine/b9a5f7da-ea26-491d-9aac-bafcdf538158/scratchpad/task1-build.log
+grep -c 'data-md-color-scheme="slate"' site/index.html
+```
+
+Expected: build exits 0 with no NEW warnings vs `baseline-build.log`; grep prints `1` (dark scheme is the default in rendered HTML).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mkdocs.yml
+git commit -m "Switch site to dark-first custom palette, rename site to SIPSIK"
+```
+
+---
+
+### Task 2: Console tokens + global chrome (`extra.css` rewrite, part 1)
+
+**Files:**
+- Modify: `docs/stylesheets/extra.css` (full replacement)
+
+**Interfaces:**
+- Consumes: `primary: custom` schemes from Task 1.
+- Produces: CSS custom properties `--mc-bg`, `--mc-panel`, `--mc-border`, `--mc-border-subtle`, `--mc-text`, `--mc-body`, `--mc-muted`, `--mc-faint`, `--mc-accent`, `--mc-accent-soft`, `--mc-success`, `--mc-info`, `--mc-danger`, `--mc-scanline`, and `--mc-mono` — Tasks 3–4 reference these names exactly.
+
+- [ ] **Step 1: Replace the entire contents of `docs/stylesheets/extra.css` with:**
+
+```css
+/* Mission Control theme — SIPSIK / Peregrine docs
+   Spec: specs/2026-07-11-site-redesign-design.md */
+
+:root {
+  --mc-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+/* ---------- tokens: dark (default) ---------- */
+[data-md-color-scheme="slate"] {
+  --mc-bg: #0a0e17;
+  --mc-panel: #0d1220;
+  --mc-border: #1f2937;
+  --mc-border-subtle: #131a2b;
+  --mc-text: #f8fafc;
+  --mc-body: #cbd5e1;
+  --mc-muted: #94a3b8;
+  --mc-faint: #64748b;
+  --mc-accent: #fbbf24;
+  --mc-accent-soft: rgba(251, 191, 36, 0.07);
+  --mc-success: #34d399;
+  --mc-info: #22d3ee;
+  --mc-danger: #f87171;
+  --mc-scanline: rgba(148, 163, 184, 0.05);
+
+  /* map tokens onto Material */
+  --md-default-bg-color: var(--mc-bg);
+  --md-default-fg-color: var(--mc-text);
+  --md-default-fg-color--light: var(--mc-body);
+  --md-default-fg-color--lighter: var(--mc-muted);
+  --md-default-fg-color--lightest: var(--mc-border);
+  --md-primary-fg-color: var(--mc-panel);
+  --md-primary-fg-color--dark: var(--mc-panel);
+  --md-primary-bg-color: var(--mc-text);
+  --md-primary-bg-color--light: var(--mc-muted);
+  --md-accent-fg-color: var(--mc-accent);
+  --md-accent-fg-color--transparent: var(--mc-accent-soft);
+  --md-typeset-a-color: var(--mc-accent);
+  --md-code-bg-color: var(--mc-panel);
+  --md-code-fg-color: #e2e8f0;
+  --md-footer-bg-color: var(--mc-panel);
+  --md-footer-bg-color--dark: var(--mc-bg);
+  --md-footer-fg-color: var(--mc-muted);
+  --md-footer-fg-color--light: var(--mc-faint);
+  --md-footer-fg-color--lighter: var(--mc-faint);
+}
+
+/* ---------- tokens: light (toggle) ---------- */
+[data-md-color-scheme="default"] {
+  --mc-bg: #faf9f7;
+  --mc-panel: #f1efeb;
+  --mc-border: #e2ded6;
+  --mc-border-subtle: #ece9e3;
+  --mc-text: #16181d;
+  --mc-body: #333944;
+  --mc-muted: #5f6672;
+  --mc-faint: #8a8f99;
+  --mc-accent: #b45309;
+  --mc-accent-soft: rgba(180, 83, 9, 0.08);
+  --mc-success: #047857;
+  --mc-info: #0e7490;
+  --mc-danger: #b91c1c;
+  --mc-scanline: rgba(22, 24, 29, 0.04);
+
+  --md-default-bg-color: var(--mc-bg);
+  --md-default-fg-color: var(--mc-text);
+  --md-default-fg-color--light: var(--mc-body);
+  --md-default-fg-color--lighter: var(--mc-muted);
+  --md-default-fg-color--lightest: var(--mc-border);
+  --md-primary-fg-color: var(--mc-panel);
+  --md-primary-fg-color--dark: var(--mc-panel);
+  --md-primary-bg-color: var(--mc-text);
+  --md-primary-bg-color--light: var(--mc-muted);
+  --md-accent-fg-color: var(--mc-accent);
+  --md-accent-fg-color--transparent: var(--mc-accent-soft);
+  --md-typeset-a-color: var(--mc-accent);
+  --md-code-bg-color: var(--mc-panel);
+  --md-code-fg-color: #1f2430;
+  --md-footer-bg-color: var(--mc-panel);
+  --md-footer-bg-color--dark: var(--mc-bg);
+  --md-footer-fg-color: var(--mc-muted);
+  --md-footer-fg-color--light: var(--mc-faint);
+  --md-footer-fg-color--lighter: var(--mc-faint);
+}
+
+/* ---------- header & nav tabs ---------- */
+.md-header {
+  border-bottom: 1px solid var(--mc-border);
+  box-shadow: none;
+}
+
+.md-header__topic {
+  font-family: var(--mc-mono);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+}
+
+.md-tabs {
+  border-bottom: 1px solid var(--mc-border);
+}
+
+.md-tabs__link {
+  font-family: var(--mc-mono);
+  font-size: 0.58rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  opacity: 0.75;
+}
+
+.md-tabs__link--active,
+.md-tabs__item--active .md-tabs__link {
+  color: var(--mc-accent);
+  border-bottom: 2px solid var(--mc-accent);
+  opacity: 1;
+}
+
+/* search box */
+.md-search__form {
+  border: 1px solid var(--mc-border);
+  border-radius: 6px;
+}
+
+/* ---------- sidebar navigation ---------- */
+.md-nav__title {
+  font-family: var(--mc-mono);
+  font-size: 0.55rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--mc-faint);
+}
+
+.md-nav__item .md-nav__link--active,
+.md-nav__item .md-nav__link--active code {
+  color: var(--mc-accent);
+}
+
+.md-nav__item .md-nav__link--active {
+  border-left: 2px solid var(--mc-accent);
+  background: var(--mc-accent-soft);
+  padding-left: 0.35rem;
+}
+
+/* ---------- footer ---------- */
+.md-footer {
+  border-top: 1px solid var(--mc-border);
+}
+
+.md-footer-meta {
+  font-family: var(--mc-mono);
+  font-size: 0.55rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+/* hide "made with mkdocs" */
+.md-footer-copyright {
+  display: none;
+}
+
+/* ---------- base typography ---------- */
+.md-typeset h1 {
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--mc-text);
+}
+
+.md-typeset h2 {
+  font-weight: 600;
+  margin-top: 1.6em;
+  padding-bottom: 0.3em;
+  border-bottom: 1px solid var(--mc-border);
+}
+```
+
+- [ ] **Step 2: Rebuild and verify tokens landed**
+
+```bash
+mkdocs build 2>&1 | tail -5
+grep -c 'mc-accent' site/stylesheets/extra.css
+```
+
+Expected: build exits 0, no new warnings; grep prints a number ≥ 10.
+
+- [ ] **Step 3: Visual smoke check (dark chrome)**
+
+```bash
+mkdocs serve -a 127.0.0.1:8000 &
+sleep 3
+curl -s http://127.0.0.1:8000/ | grep -o 'data-md-color-scheme="slate"' | head -1
+kill %1
+```
+
+Expected: `data-md-color-scheme="slate"`. (Full visual pass happens in Task 5.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/stylesheets/extra.css
+git commit -m "Rewrite extra.css: console tokens, dark/light schemes, chrome"
+```
+
+---
+
+### Task 3: Content components — tables, admonitions, math, code, images (`extra.css` part 2)
+
+**Files:**
+- Modify: `docs/stylesheets/extra.css` (append to end of file)
+
+**Interfaces:**
+- Consumes: `--mc-*` custom properties from Task 2 (exact names listed there).
+- Produces: restyled Material components used across all ~40 docs pages; `.status`/`.status-*` badge classes preserved for content use.
+
+- [ ] **Step 1: Append to `docs/stylesheets/extra.css`:**
+
+```css
+/* ---------- tables ---------- */
+.md-typeset table:not([class]) {
+  border: 1px solid var(--mc-border);
+  border-radius: 6px;
+  box-shadow: none;
+}
+
+.md-typeset table:not([class]) th {
+  background: transparent;
+  color: var(--mc-faint);
+  font-family: var(--mc-mono);
+  font-size: 0.58rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  border-bottom: 2px solid var(--mc-accent);
+}
+
+.md-typeset table:not([class]) td {
+  border-top: 1px solid var(--mc-border-subtle);
+}
+
+/* ---------- admonitions: flat console panels ---------- */
+.md-typeset .admonition,
+.md-typeset details {
+  background: var(--mc-panel);
+  border: 1px solid var(--mc-border);
+  border-left-width: 3px;
+  border-radius: 6px;
+  box-shadow: none;
+}
+
+.md-typeset .admonition-title,
+.md-typeset summary {
+  background: transparent !important;
+  font-family: var(--mc-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.58rem;
+}
+
+/* icons inherit the title color */
+.md-typeset .admonition-title::before,
+.md-typeset summary::before {
+  background-color: currentColor !important;
+}
+
+/* type colors: note/info/question = cyan */
+.md-typeset .admonition.note,
+.md-typeset .admonition.info,
+.md-typeset .admonition.question {
+  border-left-color: var(--mc-info);
+}
+.md-typeset .note > .admonition-title,
+.md-typeset .info > .admonition-title,
+.md-typeset .question > .admonition-title {
+  color: var(--mc-info);
+}
+
+/* tip/success = green */
+.md-typeset .admonition.tip,
+.md-typeset .admonition.success {
+  border-left-color: var(--mc-success);
+}
+.md-typeset .tip > .admonition-title,
+.md-typeset .success > .admonition-title {
+  color: var(--mc-success);
+}
+
+/* warning/important = amber */
+.md-typeset .admonition.warning,
+.md-typeset .admonition.important {
+  border-left-color: var(--mc-accent);
+}
+.md-typeset .warning > .admonition-title,
+.md-typeset .important > .admonition-title {
+  color: var(--mc-accent);
+}
+
+/* danger/failure = red */
+.md-typeset .admonition.danger,
+.md-typeset .admonition.failure {
+  border-left-color: var(--mc-danger);
+}
+.md-typeset .danger > .admonition-title,
+.md-typeset .failure > .admonition-title {
+  color: var(--mc-danger);
+}
+
+/* ---------- display math (MathJax / arithmatex) ---------- */
+.md-typeset div.arithmatex {
+  background: var(--mc-panel);
+  border-left: 2px solid var(--mc-accent);
+  border-radius: 0 6px 6px 0;
+  padding: 0.7em 1em;
+  overflow-x: auto;
+}
+
+/* ---------- code blocks ---------- */
+.md-typeset pre {
+  border: 1px solid var(--mc-border);
+  border-radius: 6px;
+}
+
+/* ---------- images (skip inline emoji) ---------- */
+.md-typeset img:not(.twemoji) {
+  border-radius: 6px;
+  border: 1px solid var(--mc-border);
+  box-shadow: none;
+}
+
+/* ---------- status badges ---------- */
+.md-typeset .status {
+  display: inline-block;
+  font-family: var(--mc-mono);
+  font-size: 0.55rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  padding: 0.25em 0.7em;
+  border-radius: 4px;
+  border: 1px solid;
+}
+
+.md-typeset .status-complete {
+  color: var(--mc-success);
+  border-color: var(--mc-success);
+  background: transparent;
+}
+
+.md-typeset .status-pending {
+  color: var(--mc-accent);
+  border-color: var(--mc-accent);
+  background: transparent;
+}
+
+.md-typeset .status-inprogress {
+  color: var(--mc-info);
+  border-color: var(--mc-info);
+  background: transparent;
+}
+```
+
+- [ ] **Step 2: Rebuild and verify a MathJax page and an admonition page render**
+
+```bash
+mkdocs build 2>&1 | tail -3
+grep -c 'arithmatex' site/calculations/ejection-charges/index.html
+grep -c 'admonition warning' site/construction/recovery/index.html
+```
+
+Expected: build exits 0; both greps print ≥ 1 (the CSS hooks have matching targets in real pages).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/stylesheets/extra.css
+git commit -m "Restyle tables, admonitions, math panels, code and images"
+```
+
+---
+
+### Task 4: Mission-control home page (`index.md` + home CSS)
+
+**Files:**
+- Modify: `docs/index.md` (full replacement)
+- Modify: `docs/stylesheets/extra.css` (append home components)
+
+**Interfaces:**
+- Consumes: `--mc-*` tokens (Task 2). Class names used by BOTH files (must match exactly): `mc-hero`, `mc-eyebrow`, `mc-led`, `mc-sub`, `mc-telemetry`, `mc-tile`, `mc-tile-label`, `mc-tile-value`, `mc-label`, `mc-log`, `mc-log-row`, `mc-log-ok`, `mc-log-date`, `mc-log-title`, `mc-log-detail`, `mc-doc-grid`, `mc-doc-card`, `mc-doc-num`, `mc-links`.
+
+- [ ] **Step 1: Append home components to `docs/stylesheets/extra.css`:**
+
+```css
+/* ---------- home page: mission control components ---------- */
+.mc-hero {
+  padding: 2.2rem 0 1.6rem;
+  background:
+    radial-gradient(60rem 16rem at 15% 0%, var(--mc-accent-soft), transparent),
+    repeating-linear-gradient(0deg, transparent 0 23px, var(--mc-scanline) 23px 24px);
+}
+
+.mc-eyebrow {
+  font-family: var(--mc-mono);
+  font-size: 0.6rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--mc-accent);
+  margin-bottom: 0.6rem;
+}
+
+.mc-led {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--mc-success);
+  box-shadow: 0 0 8px var(--mc-success);
+  margin: 0 0.3em;
+}
+
+.md-typeset .mc-hero h1 {
+  font-size: 1.9rem;
+  margin: 0 0 0.4rem;
+}
+
+.mc-sub {
+  font-family: var(--mc-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--mc-muted);
+  line-height: 1.8;
+}
+
+.mc-telemetry {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 1px;
+  background: var(--mc-border);
+  border: 1px solid var(--mc-border);
+  border-radius: 8px;
+  overflow: hidden;
+  margin: 1.4rem 0;
+}
+
+.md-typeset .mc-tile {
+  background: var(--mc-panel);
+  padding: 0.9rem 1rem;
+  margin: 0;
+}
+
+.mc-tile-label {
+  font-family: var(--mc-mono);
+  font-size: 0.52rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--mc-faint);
+}
+
+.mc-tile-value {
+  font-family: var(--mc-mono);
+  font-size: 1.05rem;
+  color: var(--mc-accent);
+  margin-top: 0.3rem;
+}
+
+.md-typeset .mc-label {
+  font-family: var(--mc-mono);
+  font-size: 0.55rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--mc-faint);
+  margin: 1.6rem 0 0.6rem;
+}
+
+.mc-log {
+  border-top: 1px solid var(--mc-border);
+}
+
+.md-typeset .mc-log-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+  align-items: baseline;
+  padding: 0.55rem 0;
+  margin: 0;
+  border-bottom: 1px solid var(--mc-border-subtle);
+  font-family: var(--mc-mono);
+  font-size: 0.62rem;
+}
+
+.mc-log-ok { color: var(--mc-success); }
+.mc-log-date { color: var(--mc-muted); }
+.mc-log-title { color: var(--mc-text); }
+.mc-log-detail { color: var(--mc-faint); }
+.md-typeset .mc-log-row a { margin-left: auto; }
+
+.mc-doc-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  gap: 0.7rem;
+  margin: 0.8rem 0 1.6rem;
+}
+
+.md-typeset .mc-doc-card {
+  background: var(--mc-panel);
+  border: 1px solid var(--mc-border);
+  border-radius: 8px;
+  padding: 0.9rem 1rem;
+  margin: 0;
+  transition: border-color 0.15s;
+}
+
+.md-typeset .mc-doc-card:hover {
+  border-color: var(--mc-accent);
+}
+
+.mc-doc-num {
+  font-family: var(--mc-mono);
+  font-size: 0.55rem;
+  color: var(--mc-accent);
+}
+
+.md-typeset .mc-doc-card h3 {
+  margin: 0.25rem 0 0.2rem;
+  font-size: 0.78rem;
+  font-family: var(--mc-mono);
+  letter-spacing: 0.06em;
+}
+
+.md-typeset .mc-doc-card h3 a {
+  color: var(--mc-text);
+}
+
+.md-typeset .mc-doc-card p {
+  margin: 0;
+  font-size: 0.6rem;
+  color: var(--mc-faint);
+  font-family: var(--mc-mono);
+}
+
+.md-typeset .mc-links {
+  font-family: var(--mc-mono);
+  font-size: 0.62rem;
+  display: flex;
+  gap: 1.2rem;
+  flex-wrap: wrap;
+  margin-bottom: 1.6rem;
+}
+```
+
+- [ ] **Step 2: Replace the entire contents of `docs/index.md` with:**
+
+```markdown
+---
+hide:
+  - navigation
+  - toc
+---
+
+<div class="mc-hero" markdown>
+<p class="mc-eyebrow">Mission Status <span class="mc-led"></span> All Systems Nominal</p>
+
+# SIPSIK — Tripoli L2 Certified
+
+<p class="mc-sub">Apogee Peregrine · 100 mm · dual deploy via CATS Vega<br>
+Built in Estonia · flown at Enköping, Sweden · next objective: L3</p>
+</div>
+
+<div class="mc-telemetry" markdown>
+<div class="mc-tile" markdown>
+<div class="mc-tile-label">Certs complete</div>
+<div class="mc-tile-value">L1 + L2</div>
+</div>
+<div class="mc-tile" markdown>
+<div class="mc-tile-label">Last motor</div>
+<div class="mc-tile-value">J350</div>
+</div>
+<div class="mc-tile" markdown>
+<div class="mc-tile-label">Liftoff mass</div>
+<div class="mc-tile-value">3100 g</div>
+</div>
+<div class="mc-tile" markdown>
+<div class="mc-tile-label">Main deploy</div>
+<div class="mc-tile-value">146 m</div>
+</div>
+</div>
+
+<p class="mc-label">Mission log</p>
+
+<div class="mc-log" markdown>
+<div class="mc-log-row" markdown>
+<span class="mc-log-ok">✓</span><span class="mc-log-date">2026-02-22</span><span class="mc-log-title">FLIGHT 02 — L2 CERTIFICATION</span><span class="mc-log-detail">J350 · DUAL DEPLOY · NOMINAL</span>[REPORT →](flight/flight2-analysis.md)
+</div>
+<div class="mc-log-row" markdown>
+<span class="mc-log-ok">✓</span><span class="mc-log-date">2026-01-24</span><span class="mc-log-title">FLIGHT 01 — L1 CERTIFICATION</span><span class="mc-log-detail">H128W · 140.8 M · MOTOR EJECT</span>[REPORT →](flight/flight1-analysis.md)
+</div>
+</div>
+
+<p class="mc-label">Documentation</p>
+
+<div class="mc-doc-grid" markdown>
+<div class="mc-doc-card" markdown>
+<div class="mc-doc-num">01</div>
+### [Certification](certification/index.md)
+<p>L1 ✓ · L2 ✓ · L3 planning</p>
+</div>
+<div class="mc-doc-card" markdown>
+<div class="mc-doc-num">02</div>
+### [Construction](construction/build-log.md)
+<p>Build log · ebay · fins · recovery</p>
+</div>
+<div class="mc-doc-card" markdown>
+<div class="mc-doc-num">03</div>
+### [Calculations](calculations/stability.md)
+<p>Stability · BP charges · vent holes</p>
+</div>
+<div class="mc-doc-card" markdown>
+<div class="mc-doc-num">04</div>
+### [Simulations](simulations/openrocket.md)
+<p>OpenRocket · motor selection</p>
+</div>
+<div class="mc-doc-card" markdown>
+<div class="mc-doc-num">05</div>
+### [Flight](flight/log.md)
+<p>Checklists · logs · analysis</p>
+</div>
+<div class="mc-doc-card" markdown>
+<div class="mc-doc-num">06</div>
+### [Photos](photos/index.md)
+<p>Build & launch gallery</p>
+</div>
+</div>
+
+<div class="mc-links" markdown>
+[Configurations](configurations.md)
+[Decisions](decisions/index.md)
+[Blog](blog/index.md)
+[References](references.md)
+</div>
+
+## The Story Behind Sipsik
+
+This rocket, named **SIPSIK** after the beloved Estonian cartoon character, achieved Tripoli L2 certification on 22 February 2026 at Enköping, Sweden, flying on an AeroTech J350 with dual deployment recovery via CATS Vega. L1 certification was achieved one month earlier on 24 January 2026 at the same location.
+
+The blue rocket connects to Estonian children's culture: in the Sipsik cartoon, a girl named Anu and her brother Mart build a cardboard rocket hoping to send their toy Sipsik to the moon. This rocket teaches my daughters Liza (5) and Elsa (2) how we *actually* send rockets to the sky.
+
+## Acknowledgments
+
+- **Rolf Örell** (TRA# 3728) — Certifying authority for both L1 and L2, first European Tripoli Prefect
+- **Peter Steen** — Launch support and guidance
+- **Anton Vannesjö** — Launch support and guidance
+
+---
+
+<small>
+[Tõnu Samuel](https://www.linkedin.com/in/tonusamuel/) • Software engineer • Tallinn, Estonia
+Build: [BUILD_COMMIT_HASH](BUILD_COMMIT_URL) (BUILD_DATE)
+</small>
+```
+
+Note: the `Build: [BUILD_COMMIT_HASH](BUILD_COMMIT_URL) (BUILD_DATE)` line is a CI placeholder — keep it byte-identical.
+
+- [ ] **Step 3: Rebuild and verify home structure**
+
+```bash
+mkdocs build 2>&1 | tail -3
+grep -c 'mc-tile-value' site/index.html
+grep -c 'mc-doc-card' site/index.html
+grep -c 'flight/flight2-analysis' site/index.html
+```
+
+Expected: build exits 0 with no new warnings (watch for "contains a link, but the target is not found" — that means a `.md` link path is wrong); `mc-tile-value` count = 4; `mc-doc-card` count ≥ 6; flight2 link count ≥ 1.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/index.md docs/stylesheets/extra.css
+git commit -m "Rebuild home page as mission-control console"
+```
+
+---
+
+### Task 5: Full verification pass, push, PR
+
+**Files:**
+- No source changes expected. Fixes discovered here belong to the task that introduced them (amend via a follow-up commit).
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–4.
+
+- [ ] **Step 1: Final clean build vs baseline**
+
+```bash
+mkdocs build 2>&1 | tee /private/tmp/claude-501/-Users-tonu-MyLevel1Peregrine/b9a5f7da-ea26-491d-9aac-bafcdf538158/scratchpad/final-build.log
+diff <(grep -i warning /private/tmp/claude-501/-Users-tonu-MyLevel1Peregrine/b9a5f7da-ea26-491d-9aac-bafcdf538158/scratchpad/baseline-build.log) \
+     <(grep -i warning /private/tmp/claude-501/-Users-tonu-MyLevel1Peregrine/b9a5f7da-ea26-491d-9aac-bafcdf538158/scratchpad/final-build.log)
+```
+
+Expected: diff prints nothing (no new warnings).
+
+- [ ] **Step 2: Visual pass in the browser (both schemes, desktop + ~400px width)**
+
+```bash
+mkdocs serve -a 127.0.0.1:8000
+```
+
+Check these pages in dark, then toggle to light and re-check: `/` (hero, tiles, log, grid), `/calculations/ejection-charges/` (formula panels readable), `/simulations/openrocket/` (dense tables), `/configurations.md`→`/configurations/` (tables), `/construction/recovery/` (Mermaid diagram contrast + warning admonition), `/photos/` (image borders), `/blog/2026-01-24-l1-certification/`. Confirm: nav tab underline, sidebar active highlight, search styling, footer, toggle round-trip. If the executor has browser tooling, screenshot each; otherwise ask the user to eyeball and confirm before proceeding. Known contingency: if the Mermaid diagram is unreadable on dark, STOP and report — do not improvise CSS overrides; that needs a decision.
+
+- [ ] **Step 3: Push branch and open PR (no attribution footer)**
+
+```bash
+git push -u origin feature/site-redesign
+gh pr create --title "Site redesign: Mission Control theme" --body "$(cat <<'EOF'
+## Summary
+- Dark-first "Mission Control" theme: console tokens, amber accent, mono telemetry accents (spec: specs/2026-07-11-site-redesign-design.md)
+- mkdocs.yml: dark default + custom palette, site_name → SIPSIK
+- extra.css: full rewrite (chrome, tables, admonitions, MathJax panels, code, images, home components)
+- index.md: rebuilt as mission-control landing (hero, telemetry tiles, mission log, documentation grid); story + acknowledgments preserved
+
+## Verification
+- mkdocs build clean vs baseline (no new warnings)
+- Visual pass in both schemes: home, ejection-charges (MathJax), openrocket (tables), recovery (Mermaid + admonitions), photos, blog
+EOF
+)"
+```
+
+Expected: PR URL printed. **STOP here — do not merge.**
+
+---
+
+## Self-review notes
+
+- Spec coverage: tokens (T2), typography (T2), home page (T4), nav tabs/sidebar/search/footer (T2), tables/admonitions/math/code/images/badges (T3), site_name (T1), dark default + light toggle (T1+T2), out-of-scope respected (no other files), risks → T5 step 2 (Mermaid, MathJax, light-mode contrast, dense tables).
+- Class names cross-checked between T4 CSS and T4 index.md — 19 `mc-*` classes match.
+- No placeholders; every code step contains full content.

--- a/specs/2026-07-11-site-redesign-design.md
+++ b/specs/2026-07-11-site-redesign-design.md
@@ -1,0 +1,140 @@
+# Site Redesign — Mission Control (Amber)
+
+**Date:** 2026-07-11
+**Status:** Design approved, implementation pending
+
+## Goal
+
+Replace the stock MkDocs Material indigo look with a distinctive "Mission
+Control" visual identity across the whole site: a dark flight-console
+aesthetic with monospace telemetry accents, applied to the landing page and
+all documentation pages, without losing any Material functionality (search,
+light/dark toggle, MathJax, Mermaid, blog, CI deploy).
+
+## Decision summary
+
+- **Direction:** Mission Control — chosen from four presented options
+  (Mission Control, Blueprint, Nordic Minimal, Launch Day).
+- **Accent:** Amber (A1), chosen over Ice cyan (A2) and Phosphor green (A3).
+- **Scheme:** Dark by default; light-mode toggle retained with a warm-white
+  variant.
+- **Implementation surface:** three files only — `mkdocs.yml`,
+  `docs/stylesheets/extra.css`, `docs/index.md`. No Jinja template
+  overrides, no new fonts, no content changes on other pages.
+
+## Design tokens
+
+### Dark scheme (default)
+
+| Token | Value | Use |
+|---|---|---|
+| bg-page | `#0a0e17` | Page background |
+| bg-panel | `#0d1220` | Cards, tiles, sidebar, code/formula panels |
+| border | `#1f2937` | Panel borders, dividers |
+| border-subtle | `#131a2b` | Table row separators, log rows |
+| text-primary | `#f8fafc` | Headings, emphasized text |
+| text-body | `#cbd5e1` | Body copy |
+| text-muted | `#94a3b8` | Secondary text, inactive nav |
+| text-faint | `#64748b` | Micro-labels, captions |
+| accent | `#fbbf24` | Data readouts, links, active nav, table header rules, warnings |
+| success | `#34d399` | Status LED, checkmarks, "nominal" states only |
+| info | `#22d3ee` | Note admonitions, sparing secondary accent |
+
+### Light scheme (toggle)
+
+Same structure, remapped: warm-white page (`#faf9f7`), panel `#f1efeb`,
+ink text (`#16181d`), borders `#e2ded6`. Text-level amber accents use
+`#b45309` (amber-700) because `#fbbf24` fails contrast on white; large
+non-text rules/underlines may stay `#fbbf24`. Success `#047857`.
+
+Both palettes are defined as CSS custom properties under
+`[data-md-color-scheme="slate"]` and `[data-md-color-scheme="default"]`.
+
+## Typography
+
+- **Body:** Inter (already configured) — all prose, table contents.
+- **Data/labels/code:** JetBrains Mono (already configured) — telemetry
+  values, micro-labels, code.
+- **Micro-label idiom:** 10–11px mono, uppercase, letter-spacing
+  0.15–0.25em, text-faint color. Used for eyebrows, table headers, card
+  numbers, section labels.
+- H1 Inter 700, H2 Inter 600 with a subtle border-bottom rule.
+- No new font loads.
+
+## Home page (`docs/index.md`)
+
+Front matter hides the sidebar and TOC (`hide: [navigation, toc]`); the
+top nav tabs remain. Sections in order:
+
+1. **Hero** — mono eyebrow `MISSION STATUS ● ALL SYSTEMS NOMINAL` with a
+   glowing green LED dot; H1 `SIPSIK — TRIPOLI L2 CERTIFIED`; two mono
+   sub-lines (Apogee Peregrine · 100 mm · dual deploy via CATS Vega /
+   built in Estonia · flown at Enköping, Sweden · next objective: L3).
+   Background: faint horizontal scanlines + amber radial glow.
+2. **Telemetry tiles** (4-up grid, 1px-gap borders): CERTS COMPLETE
+   `L1 + L2` · LAST MOTOR `J350` · LIFTOFF MASS `3100 g` · MAIN DEPLOY
+   `146 m`.
+3. **Mission Log** — one row per cert flight with green check, date,
+   title, mono details, and an amber `REPORT →` link:
+   - `✓ 2026-02-22 FLIGHT 02 — L2 CERTIFICATION · J350 · DUAL DEPLOY · NOMINAL` → `flight/flight2-analysis.md`
+   - `✓ 2026-01-24 FLIGHT 01 — L1 CERTIFICATION · H128W · 140.8 M · MOTOR EJECT` → `flight/flight1-analysis.md`
+4. **Documentation grid** — six numbered cards (01 Certification,
+   02 Construction, 03 Calculations, 04 Simulations, 05 Flight,
+   06 Photos), each with a one-line mono description. A compact links
+   row below covers Configurations, Decisions, Blog, References.
+5. **Story + acknowledgments** — existing Sipsik story text and
+   acknowledgments preserved as prose, restyled; build-hash footer line
+   preserved.
+
+## Documentation pages (CSS-only restyle)
+
+- **Nav tabs:** mono uppercase 11px letterspaced; active tab gets a 2px
+  amber underline. Header bar `bg-panel`.
+- **Site identity:** `site_name` changes `Peregrine` → `SIPSIK` to match
+  the approved mockups (affects browser titles). Logo image retained.
+- **Sidebar:** section titles as micro-labels; active item amber text,
+  2px amber left bar, faint amber background tint.
+- **Search:** dark pill-style input.
+- **Tables:** header cells become micro-labels with an amber
+  border-bottom rule (replaces the solid indigo header background); body
+  stays Inter; row separators `border-subtle`; existing `.specs-table`
+  and comparison tables must remain readable.
+- **Admonitions:** flat `bg-panel` with a 1px type-colored border and
+  colored title — warning/danger amber-red family, note/info cyan,
+  success green. No heavy shadows.
+- **Formula blocks (MathJax display math):** `bg-panel` panel with 2px
+  amber left border and padding; text color inherits scheme.
+- **Code blocks:** `bg-panel` with `border` outline.
+- **Images:** 1px `border`, 6px radius; current drop shadow removed.
+- **Status badges** (`.status-*`): recolored to console palette.
+- **Existing `.card`/`.grid` classes** (used on configurations page
+  etc.): restyled to match the documentation grid.
+- **Footer:** dark, minimal, mono micro-labels.
+
+## Out of scope
+
+No nav restructuring, no content edits beyond the `index.md` layout, no
+new pages, no template overrides, no font additions, no changes to CI.
+
+## Risks and mitigations
+
+- **Mermaid on dark:** Material themes Mermaid per scheme automatically;
+  verify diagram contrast on the dark scheme and override Mermaid CSS
+  variables only if needed.
+- **MathJax legibility:** formulas inherit text color; verify on both
+  schemes on `calculations/ejection-charges.md`.
+- **Amber contrast in light mode:** mitigated via `#b45309` for
+  text-level accents.
+- **Table restyle regressions:** visual pass on `configurations.md` and
+  `simulations/` pages, which have the densest tables.
+
+## Verification plan
+
+1. `mkdocs build` completes with no new warnings (compare against a
+   baseline build from main).
+2. Visual pass in both schemes at desktop and mobile widths: home,
+   `calculations/ejection-charges.md` (MathJax), `simulations/openrocket.md`
+   (tables), `configurations.md` (cards + tables), a Mermaid-bearing page,
+   `photos/index.md`, one blog post.
+3. Check nav tabs, sidebar highlight, search styling, footer, and the
+   light/dark toggle round-trip.


### PR DESCRIPTION
## Summary
- Dark-first "Mission Control" theme: console tokens, amber accent, mono telemetry accents (spec: specs/2026-07-11-site-redesign-design.md, plan: plans/2026-07-11-site-redesign.md)
- mkdocs.yml: dark default + custom palette, site_name → SIPSIK
- extra.css: full rewrite (chrome, tables, admonitions, MathJax panels, code, images, home components)
- index.md: rebuilt as mission-control landing (hero, telemetry tiles, mission log, documentation grid); story + acknowledgments preserved
- Follow-up fix: mission-log/links md_in_html span-mode flex wrapping, admonition border-color cascade override

## Verification
- mkdocs build clean vs baseline (warning set byte-identical; 6 pre-existing warnings untouched)
- Per-task reviews on all 5 tasks + final whole-branch review: Ready to merge
- Visual pass in both schemes (human-verified): home, ejection-charges (MathJax), openrocket (tables), recovery (Mermaid + admonitions), photos, configurations, blog; light/dark toggle round-trip; mobile width